### PR TITLE
feat: integra segnali cross-repo (SO catalog_signals + DI pipeline_signals)

### DIFF
--- a/schemas/repo-signals.md
+++ b/schemas/repo-signals.md
@@ -116,6 +116,12 @@ per coordinare il parser ACB.
 ACB mostra nel `session_bootstrap.md` solo i segnali `warn` e `error`.
 I segnali `ok` appaiono solo nei conteggi di `summary`.
 
+**Nota per i consumer**: il significato di `ok` dipende dal `topic` del file.
+Per `pipeline_state` (dataset-incubator), `ok` significa **struttura candidate
+coerente e layer mart presente** — non implica che la pipeline abbia girato,
+che i dati siano freschi o che il candidate sia pronto per la promozione.
+Leggere sempre il campo `detail` per il contesto specifico del segnale.
+
 ---
 
 ## Legacy: source-observatory

--- a/schemas/repo-signals.md
+++ b/schemas/repo-signals.md
@@ -1,0 +1,138 @@
+# Repo Signals — Standard di interoperabilità per ACB
+
+Spec per i file JSON che i repo del Lab possono pubblicare affinché
+`agent-context-builder` li consumi durante il build del contesto.
+
+---
+
+## Scopo
+
+Ogni repo ha conoscenza locale che ACB non può derivare da GitHub:
+- **source-observatory**: salute delle fonti dati (endpoint up/down, regressioni)
+- **dataset-incubator**: stato dei candidati nel pipeline (stage, blocchi, pronti per promozione)
+- (futuri repo): qualunque segnale operativo rilevante per un agente
+
+Anziché costruire parser ad-hoc per ogni repo, ACB legge file JSON che seguono
+questo standard e li aggrega in `workspace_triage.json` e `session_bootstrap.md`.
+
+---
+
+## Convenzione di posizionamento
+
+Ogni repo pubblica il proprio file in una path nota e stabile, committata nel
+repo stesso e aggiornata da CI (o manualmente). ACB la legge via
+`raw.githubusercontent.com` — nessun clone locale necessario.
+
+Paths per repo attivi:
+
+| Repo | Path nel repo | Nota |
+|------|--------------|------|
+| `source-observatory` | `data/catalog/catalog_signals.json` | formato legacy (vedi §Legacy) |
+| `dataset-incubator` | `registry/pipeline_signals.json` | adotta questo standard |
+
+---
+
+## Schema (v1)
+
+```json
+{
+  "schema_version": "1",
+  "generated_at": "2026-04-15",
+  "repo": "dataset-incubator",
+  "topic": "pipeline_state",
+  "summary": {
+    "total": 20,
+    "by_status": { "ok": 16, "warn": 3, "error": 1 }
+  },
+  "signals": [
+    {
+      "id": "irpef-comunale",
+      "status": "ok",
+      "label": "irpef-comunale",
+      "detail": "stage: incubating — anni 2019-2023, fonte: mef",
+      "action": ""
+    },
+    {
+      "id": "ispra-balneazione",
+      "status": "warn",
+      "label": "ispra-balneazione",
+      "detail": "stage: incubating — nessun mart SQL, issue aperta da 60+ giorni",
+      "action": "valutare se bloccare o archiviare"
+    }
+  ]
+}
+```
+
+### Campi obbligatori
+
+| Campo | Tipo | Descrizione |
+|-------|------|-------------|
+| `schema_version` | `"1"` | Versione dello schema (stringa, non numero) |
+| `generated_at` | `YYYY-MM-DD` | Data di generazione |
+| `repo` | string | Nome del repo GitHub (es. `"dataset-incubator"`) |
+| `topic` | string | Dominio del segnale — vedi §Topic |
+| `signals` | array | Lista di segnali — vedi §Segnale |
+
+### Campi opzionali
+
+| Campo | Tipo | Descrizione |
+|-------|------|-------------|
+| `summary` | object | Conteggi aggregati per status |
+| `summary.total` | int | Totale elementi osservati |
+| `summary.by_status` | object | Conteggi per valore di status |
+
+---
+
+## Valori di `topic`
+
+| Valore | Repo | Significato |
+|--------|------|-------------|
+| `catalog_health` | source-observatory | Salute degli endpoint delle fonti |
+| `pipeline_state` | dataset-incubator | Stato dei candidati nel pipeline |
+
+Nuovi topic: aprire issue in `agent-context-builder` prima di adottarli,
+per coordinare il parser ACB.
+
+---
+
+## Schema del segnale (`signals[]`)
+
+| Campo | Tipo | Obbligatorio | Descrizione |
+|-------|------|-------------|-------------|
+| `id` | string | sì | Identificatore stabile (slug del dataset, nome fonte, ecc.) |
+| `status` | `"ok"` \| `"warn"` \| `"error"` | sì | Stato sintetico |
+| `label` | string | sì | Nome leggibile da mostrare in UI/bootstrap |
+| `detail` | string | sì | Descrizione human-readable dello stato corrente |
+| `action` | string | sì | Azione suggerita — stringa vuota `""` se nessuna |
+
+### Semantica di `status`
+
+| Valore | Significato |
+|--------|-------------|
+| `ok` | Nessun problema noto, nessuna azione richiesta |
+| `warn` | Attenzione: qualcosa è anomalo ma non bloccante |
+| `error` | Bloccante o regressione: richiede azione |
+
+ACB mostra nel `session_bootstrap.md` solo i segnali `warn` e `error`.
+I segnali `ok` appaiono solo nei conteggi di `summary`.
+
+---
+
+## Legacy: source-observatory
+
+`source-observatory` usa un formato precedente allo standard (`catalog_signals.json`).
+ACB mantiene un parser dedicato (`signals.py::parse_source_observatory_signals`)
+che mappa il vecchio formato sul modello interno.
+
+Migrazione pianificata: quando SO adotterà questo schema, il parser legacy
+verrà rimosso. Non c'è urgenza — il formato SO è stabile e ben definito.
+
+---
+
+## Come aggiungere un nuovo repo
+
+1. Definire il `topic` (aprire issue in ACB se non esiste)
+2. Scrivere lo script che produce il JSON (es. `scripts/build_pipeline_signals.py`)
+3. Aggiungere il file alla CI del repo (workflow che lo aggiorna e committa)
+4. Registrare la path in ACB (`dataciviclab.config.yml` o nel codice di `GitHubCollector`)
+5. Aggiungere il parser in `render.py` se il topic non è già supportato

--- a/src/agent_context_builder/github.py
+++ b/src/agent_context_builder/github.py
@@ -104,6 +104,32 @@ class GitHubCollector:
             )
         return prs
 
+    def get_raw_file(self, repo: str, path: str, ref: str = "main") -> str | None:
+        """Fetch raw file content from GitHub.
+
+        Uses raw.githubusercontent.com — works without token on public repos.
+        On failure, records the error in self.fetch_errors and returns None.
+
+        Args:
+            repo: Repository name (under self.org)
+            path: File path within the repo
+            ref: Branch or tag (default: main)
+
+        Returns:
+            Raw file content as string, or None on failure.
+        """
+        url = f"https://raw.githubusercontent.com/{self.org}/{repo}/{ref}/{path}"
+        headers = {}
+        if self.token:
+            headers["Authorization"] = f"token {self.token}"
+        try:
+            response = requests.get(url, headers=headers, timeout=10)
+            response.raise_for_status()
+            return response.text
+        except Exception as exc:
+            self.fetch_errors[f"{repo}:{path}"] = str(exc)
+            return None
+
     def _get_repo_issues(self, repo: str, state: str = "open") -> list[Issue]:
         """Get issues for a specific repo (excluding pull requests).
 

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -11,7 +11,12 @@ from .config import Config
 from .discussions import Discussion, DiscussionCollector
 from .github import GitHubCollector, PR
 from .git_local import GitLocalCollector, GitState
-from .signals import SourceObservatorySignals, parse_source_observatory_signals
+from .signals import (
+    RepoSignals,
+    SourceObservatorySignals,
+    parse_repo_signals,
+    parse_source_observatory_signals,
+)
 
 
 class Renderer:
@@ -41,6 +46,7 @@ class Renderer:
         self.fixed_timestamp = fixed_timestamp or datetime.now().isoformat()
         # Cache for remote signal fetches — avoids double requests within one build
         self._so_signals_cache: SourceObservatorySignals | None | type[_UNSET] = _UNSET
+        self._di_signals_cache: RepoSignals | None | type[_UNSET] = _UNSET
 
     def render_session_bootstrap(self) -> str:
         """Render session_bootstrap.md.
@@ -123,6 +129,10 @@ class Renderer:
         # Source health (only issues — skip stable sources)
         so = self._fetch_source_observatory_signals()
         lines += self._render_source_health_section(so)
+
+        # Pipeline state (only warn/error candidates)
+        di = self._fetch_di_pipeline_signals()
+        lines += self._render_pipeline_state_section(di)
 
         return "\n".join(lines)
 
@@ -246,6 +256,7 @@ class Renderer:
             },
             "warnings": self._collect_warnings(prs, repos_state),
             "source_health": self._build_source_health_dict(),
+            "pipeline_state": self._build_pipeline_state_dict(),
         }
         return triage
 
@@ -282,6 +293,79 @@ class Renderer:
                     "suggested_action": s.suggested_action,
                 }
                 for s in so.alerts
+            ],
+        }
+
+    def _fetch_di_pipeline_signals(self) -> RepoSignals | None:
+        if self._di_signals_cache is not _UNSET:
+            return self._di_signals_cache  # type: ignore[return-value]
+        raw = self.github_collector.get_raw_file(
+            "dataset-incubator", "registry/pipeline_signals.json"
+        )
+        if raw is None:
+            self._di_signals_cache = None
+            return None
+        try:
+            result = parse_repo_signals(raw)
+        except ValueError as exc:
+            self.github_collector.fetch_errors["dataset-incubator:pipeline_signals"] = str(exc)
+            result = None
+        self._di_signals_cache = result
+        return result
+
+    def _render_pipeline_state_section(self, di: RepoSignals | None) -> list[str]:
+        lines = []
+        lines.append("## Pipeline State")
+        lines.append("")
+        if di is None:
+            err = self.github_collector.fetch_errors.get(
+                "dataset-incubator:registry/pipeline_signals.json"
+            ) or self.github_collector.fetch_errors.get(
+                "dataset-incubator:pipeline_signals"
+            )
+            if err:
+                lines.append(f"> *pipeline_signals unavailable — {err}*")
+            else:
+                lines.append("> *pipeline_signals unavailable*")
+            lines.append("")
+            return lines
+
+        summary = di.summary
+        total = summary.get("total", len(di.signals))
+        by_status = summary.get("by_status", {})
+        actionable = di.actionable
+        if actionable:
+            for s in actionable:
+                lines.append(f"- **{s.label}** [{s.status}]: {s.detail}")
+                if s.action:
+                    lines.append(f"  - azione: {s.action}")
+        else:
+            lines.append(f"*{total} candidates, tutti ok*")
+        lines.append(
+            f"  *(as of {di.generated_at} — "
+            + ", ".join(f"{v} {k}" for k, v in sorted(by_status.items()) if v)
+            + ")*"
+        )
+        lines.append("")
+        return lines
+
+    def _build_pipeline_state_dict(self) -> dict[str, Any]:
+        di = self._fetch_di_pipeline_signals()
+        if di is None:
+            return {
+                "available": False,
+                "errors": {
+                    k: v for k, v in self.github_collector.fetch_errors.items()
+                    if "dataset-incubator" in k
+                },
+            }
+        return {
+            "available": True,
+            "generated_at": di.generated_at,
+            "summary": di.summary,
+            "actionable": [
+                {"id": s.id, "status": s.status, "detail": s.detail, "action": s.action}
+                for s in di.actionable
             ],
         }
 

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -3,10 +3,6 @@
 from datetime import datetime
 from typing import Any
 
-
-class _UNSET:
-    """Sentinel for uninitialized cache values."""
-
 from .config import Config
 from .discussions import Discussion, DiscussionCollector
 from .github import GitHubCollector, PR
@@ -17,6 +13,10 @@ from .signals import (
     parse_repo_signals,
     parse_source_observatory_signals,
 )
+
+
+class _UNSET:
+    """Sentinel for uninitialized cache values."""
 
 
 class Renderer:
@@ -172,7 +172,8 @@ class Renderer:
             lines.append("")
             return lines
 
-        issues = so.alerts
+        # Show regressions first, then other alerts (mutually exclusive sets)
+        issues = so.regressions + so.alerts
         if issues:
             for s in issues:
                 lines.append(f"- **{s.source}** ({s.protocol}): {s.result} — {s.detail}")

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -3,10 +3,15 @@
 from datetime import datetime
 from typing import Any
 
+
+class _UNSET:
+    """Sentinel for uninitialized cache values."""
+
 from .config import Config
 from .discussions import Discussion, DiscussionCollector
 from .github import GitHubCollector, PR
 from .git_local import GitLocalCollector, GitState
+from .signals import SourceObservatorySignals, parse_source_observatory_signals
 
 
 class Renderer:
@@ -34,6 +39,8 @@ class Renderer:
         self.git_collector = git_collector
         self.discussion_collector = discussion_collector
         self.fixed_timestamp = fixed_timestamp or datetime.now().isoformat()
+        # Cache for remote signal fetches — avoids double requests within one build
+        self._so_signals_cache: SourceObservatorySignals | None | type[_UNSET] = _UNSET
 
     def render_session_bootstrap(self) -> str:
         """Render session_bootstrap.md.
@@ -113,7 +120,59 @@ class Renderer:
                 lines.append(f"- {topic_name}")
             lines.append("")
 
+        # Source health (only issues — skip stable sources)
+        so = self._fetch_source_observatory_signals()
+        lines += self._render_source_health_section(so)
+
         return "\n".join(lines)
+
+    def _fetch_source_observatory_signals(self) -> SourceObservatorySignals | None:
+        if self._so_signals_cache is not _UNSET:
+            return self._so_signals_cache  # type: ignore[return-value]
+        raw = self.github_collector.get_raw_file(
+            "source-observatory", "data/catalog/catalog_signals.json"
+        )
+        if raw is None:
+            self._so_signals_cache = None
+            return None
+        try:
+            result = parse_source_observatory_signals(raw)
+        except ValueError as exc:
+            self.github_collector.fetch_errors["source-observatory:catalog_signals"] = str(exc)
+            result = None
+        self._so_signals_cache = result
+        return result
+
+    def _render_source_health_section(
+        self, so: SourceObservatorySignals | None
+    ) -> list[str]:
+        lines = []
+        lines.append("## Source Health")
+        lines.append("")
+        if so is None:
+            err = self.github_collector.fetch_errors.get(
+                "source-observatory:data/catalog/catalog_signals.json"
+            ) or self.github_collector.fetch_errors.get(
+                "source-observatory:catalog_signals"
+            )
+            if err:
+                lines.append(f"> *catalog_signals unavailable — {err}*")
+            else:
+                lines.append("> *catalog_signals unavailable*")
+            lines.append("")
+            return lines
+
+        issues = so.alerts
+        if issues:
+            for s in issues:
+                lines.append(f"- **{s.source}** ({s.protocol}): {s.result} — {s.detail}")
+                if s.suggested_action and s.suggested_action != "nessuna":
+                    lines.append(f"  - azione: {s.suggested_action}")
+        else:
+            lines.append(f"*All {so.sources_checked} sources stable* (as of {so.captured_at})")
+        lines.append(f"  *(captured {so.captured_at}, {so.sources_checked} sources checked)*")
+        lines.append("")
+        return lines
 
     def render_workspace_triage(self) -> dict[str, Any]:
         """Render workspace_triage.json.
@@ -186,8 +245,45 @@ class Renderer:
                 for repo, state in repos_state.items()
             },
             "warnings": self._collect_warnings(prs, repos_state),
+            "source_health": self._build_source_health_dict(),
         }
         return triage
+
+    def _build_source_health_dict(self) -> dict[str, Any]:
+        so = self._fetch_source_observatory_signals()
+        if so is None:
+            return {
+                "available": False,
+                "errors": {
+                    k: v for k, v in self.github_collector.fetch_errors.items()
+                    if "source-observatory" in k
+                },
+            }
+        return {
+            "available": True,
+            "captured_at": so.captured_at,
+            "sources_checked": so.sources_checked,
+            "regressions": [
+                {
+                    "source": s.source,
+                    "protocol": s.protocol,
+                    "detail": s.detail,
+                    "suggested_action": s.suggested_action,
+                }
+                for s in so.regressions
+            ],
+            "alerts": [
+                {
+                    "source": s.source,
+                    "protocol": s.protocol,
+                    "signal_type": s.signal_type,
+                    "result": s.result,
+                    "detail": s.detail,
+                    "suggested_action": s.suggested_action,
+                }
+                for s in so.alerts
+            ],
+        }
 
     def _collect_warnings(
         self, prs: list[PR], repos_state: dict[str, GitState]

--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -1,0 +1,72 @@
+"""Signal data models and parsers for pre-computed Lab artifacts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class SourceSignal:
+    """Single source health signal from source-observatory."""
+
+    source: str
+    protocol: str
+    signal_type: str
+    result: str
+    detail: str
+    suggested_action: str
+
+
+@dataclass
+class SourceObservatorySignals:
+    """Aggregated signals from source-observatory catalog_signals.json."""
+
+    captured_at: str
+    sources_checked: int
+    signals: list[SourceSignal] = field(default_factory=list)
+
+    @property
+    def regressions(self) -> list[SourceSignal]:
+        return [s for s in self.signals if s.result == "regressione"]
+
+    @property
+    def alerts(self) -> list[SourceSignal]:
+        return [s for s in self.signals if s.signal_type not in ("no signal", "")]
+
+
+def parse_source_observatory_signals(raw: str) -> SourceObservatorySignals:
+    """Parse raw JSON string into SourceObservatorySignals.
+
+    Args:
+        raw: Raw JSON content of catalog_signals.json
+
+    Returns:
+        Parsed SourceObservatorySignals instance
+
+    Raises:
+        ValueError: If the JSON is invalid or missing required fields
+    """
+    try:
+        data: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON: {exc}") from exc
+
+    signals = [
+        SourceSignal(
+            source=s.get("source", ""),
+            protocol=s.get("protocol", ""),
+            signal_type=s.get("signal_type", ""),
+            result=s.get("result", ""),
+            detail=s.get("detail", ""),
+            suggested_action=s.get("suggested_action", ""),
+        )
+        for s in data.get("signals", [])
+    ]
+
+    return SourceObservatorySignals(
+        captured_at=data.get("captured_at", "unknown"),
+        sources_checked=data.get("sources_checked", len(signals)),
+        signals=signals,
+    )

--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -36,6 +36,72 @@ class SourceObservatorySignals:
         return [s for s in self.signals if s.signal_type not in ("no signal", "")]
 
 
+@dataclass
+class RepoSignal:
+    """Single signal entry following the repo-signals standard v1."""
+
+    id: str
+    status: str  # ok | warn | error
+    label: str
+    detail: str
+    action: str
+
+
+@dataclass
+class RepoSignals:
+    """Aggregated signals from a repo following the repo-signals standard v1."""
+
+    schema_version: str
+    generated_at: str
+    repo: str
+    topic: str
+    signals: list[RepoSignal] = field(default_factory=list)
+    summary: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def actionable(self) -> list[RepoSignal]:
+        """Signals that are warn or error (shown in bootstrap)."""
+        return [s for s in self.signals if s.status in ("warn", "error")]
+
+
+def parse_repo_signals(raw: str) -> RepoSignals:
+    """Parse a repo-signals standard v1 JSON string.
+
+    Args:
+        raw: Raw JSON content of a pipeline_signals.json (or compatible)
+
+    Returns:
+        Parsed RepoSignals instance
+
+    Raises:
+        ValueError: If the JSON is invalid
+    """
+    try:
+        data: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON: {exc}") from exc
+
+    signals = [
+        RepoSignal(
+            id=s.get("id", ""),
+            status=s.get("status", "ok"),
+            label=s.get("label", s.get("id", "")),
+            detail=s.get("detail", ""),
+            action=s.get("action", ""),
+        )
+        for s in data.get("signals", [])
+    ]
+
+    return RepoSignals(
+        schema_version=str(data.get("schema_version", "1")),
+        generated_at=data.get("generated_at", "unknown"),
+        repo=data.get("repo", ""),
+        topic=data.get("topic", ""),
+        signals=signals,
+        summary=data.get("summary", {}),
+    )
+
+
 def parse_source_observatory_signals(raw: str) -> SourceObservatorySignals:
     """Parse raw JSON string into SourceObservatorySignals.
 

--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -29,11 +29,21 @@ class SourceObservatorySignals:
 
     @property
     def regressions(self) -> list[SourceSignal]:
+        """Signals where result == 'regressione' (status degraded from previous run)."""
         return [s for s in self.signals if s.result == "regressione"]
 
     @property
     def alerts(self) -> list[SourceSignal]:
-        return [s for s in self.signals if s.signal_type not in ("no signal", "")]
+        """Non-stable signals that are NOT regressions (e.g. warnings, anomalies).
+
+        Mutually exclusive with regressions: each signal appears in at most one list.
+        """
+        regression_sources = {s.source for s in self.regressions}
+        return [
+            s for s in self.signals
+            if s.signal_type not in ("no signal", "")
+            and s.source not in regression_sources
+        ]
 
 
 @dataclass

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -279,7 +279,7 @@ def test_render_triage_source_health_unavailable():
 
 
 def test_render_signals_cached_across_bootstrap_and_triage():
-    """get_raw_file is called only once even if bootstrap and triage both render."""
+    """Each remote file is fetched exactly once across bootstrap + triage."""
     config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
     gh = _make_github_mock(raw_file=_sample_so_json(regression=False))
     renderer = Renderer(config, gh, _make_git_mock())
@@ -287,7 +287,11 @@ def test_render_signals_cached_across_bootstrap_and_triage():
     renderer.render_session_bootstrap()
     renderer.render_workspace_triage()
 
-    assert gh.get_raw_file.call_count == 1
+    # Two distinct files (SO catalog_signals + DI pipeline_signals), each fetched once
+    assert gh.get_raw_file.call_count == 2
+    paths_fetched = [call.args[1] for call in gh.get_raw_file.call_args_list]
+    assert "data/catalog/catalog_signals.json" in paths_fetched
+    assert "registry/pipeline_signals.json" in paths_fetched
 
 
 def test_render_topic_index():

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -278,10 +278,39 @@ def test_render_triage_source_health_unavailable():
     assert triage["source_health"]["available"] is False
 
 
+def _sample_di_json() -> str:
+    return json.dumps({
+        "schema_version": "1",
+        "generated_at": "2026-04-16T10:00:00",
+        "repo": "dataciviclab/dataset-incubator",
+        "topic": "pipeline_state",
+        "signals": [
+            {"id": "irpef-comunale", "status": "ok", "label": "irpef-comunale", "detail": "", "action": ""},
+        ],
+        "summary": {"ok": 1, "warn": 0, "error": 0},
+    })
+
+
 def test_render_signals_cached_across_bootstrap_and_triage():
-    """Each remote file is fetched exactly once across bootstrap + triage."""
+    """Each remote file is fetched exactly once across bootstrap + triage.
+
+    Uses side_effect so SO and DI fetches return their respective realistic JSON,
+    validating parse_repo_signals on real DI-shaped data.
+    """
     config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
-    gh = _make_github_mock(raw_file=_sample_so_json(regression=False))
+    gh = _make_github_mock()
+
+    so_json = _sample_so_json(regression=False)
+    di_json = _sample_di_json()
+
+    def _raw_file_side_effect(repo, path, ref="main"):
+        if path == "data/catalog/catalog_signals.json":
+            return so_json
+        if path == "registry/pipeline_signals.json":
+            return di_json
+        return None
+
+    gh.get_raw_file.side_effect = _raw_file_side_effect
     renderer = Renderer(config, gh, _make_git_mock())
 
     renderer.render_session_bootstrap()

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import json
+
 from agent_context_builder.config import Config
 from agent_context_builder.discussions import Discussion, DiscussionCollector
 from agent_context_builder.git_local import GitLocalCollector, GitState
@@ -12,11 +14,28 @@ from agent_context_builder.render import Renderer
 _UNAVAILABLE = GitState(available=False, reason="path_not_found", dirty=None, current_branch=None)
 
 
-def _make_github_mock(prs=None, issues=None, fetch_errors=None):
+def _sample_so_json(regression: bool = False) -> str:
+    signals = []
+    if regression:
+        signals.append({
+            "source": "anac", "protocol": "ckan",
+            "signal_type": "health", "result": "regressione",
+            "detail": "WAF attivo.", "suggested_action": "monitorare",
+        })
+    signals.append({
+        "source": "istat_sdmx", "protocol": "sdmx",
+        "signal_type": "no signal", "result": "stabile",
+        "detail": "ok", "suggested_action": "nessuna",
+    })
+    return json.dumps({"captured_at": "2026-04-12", "sources_checked": len(signals), "signals": signals})
+
+
+def _make_github_mock(prs=None, issues=None, fetch_errors=None, raw_file=None):
     m = MagicMock(spec=GitHubCollector)
     m.get_prs.return_value = prs or []
     m.get_issues.return_value = issues or []
     m.fetch_errors = fetch_errors or {}
+    m.get_raw_file.return_value = raw_file  # None by default = signal fetch fails gracefully
     return m
 
 
@@ -185,6 +204,90 @@ def test_render_triage_without_discussion_collector():
 
     assert triage["open_discussions"] is None
     assert triage["discussions"] == []
+
+
+def test_render_bootstrap_with_source_health_regression():
+    """Bootstrap includes Source Health section with regression detail."""
+    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
+    renderer = Renderer(
+        config,
+        _make_github_mock(raw_file=_sample_so_json(regression=True)),
+        _make_git_mock(),
+    )
+    bootstrap = renderer.render_session_bootstrap()
+
+    assert "Source Health" in bootstrap
+    assert "anac" in bootstrap
+    assert "WAF attivo" in bootstrap
+
+
+def test_render_bootstrap_source_health_all_stable():
+    """Bootstrap Source Health shows 'all stable' when no alerts."""
+    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
+    renderer = Renderer(
+        config,
+        _make_github_mock(raw_file=_sample_so_json(regression=False)),
+        _make_git_mock(),
+    )
+    bootstrap = renderer.render_session_bootstrap()
+
+    assert "Source Health" in bootstrap
+    assert "stable" in bootstrap
+
+
+def test_render_bootstrap_source_health_unavailable():
+    """Bootstrap Source Health shows unavailable message when fetch fails."""
+    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
+    renderer = Renderer(
+        config,
+        _make_github_mock(raw_file=None),  # fetch returns None = not found
+        _make_git_mock(),
+    )
+    bootstrap = renderer.render_session_bootstrap()
+
+    assert "Source Health" in bootstrap
+    assert "unavailable" in bootstrap
+
+
+def test_render_triage_source_health_available():
+    """Triage includes source_health with regressions when signals fetched."""
+    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
+    renderer = Renderer(
+        config,
+        _make_github_mock(raw_file=_sample_so_json(regression=True)),
+        _make_git_mock(),
+    )
+    triage = renderer.render_workspace_triage()
+
+    sh = triage["source_health"]
+    assert sh["available"] is True
+    assert len(sh["regressions"]) == 1
+    assert sh["regressions"][0]["source"] == "anac"
+
+
+def test_render_triage_source_health_unavailable():
+    """Triage source_health marks unavailable when fetch fails."""
+    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
+    renderer = Renderer(
+        config,
+        _make_github_mock(raw_file=None),
+        _make_git_mock(),
+    )
+    triage = renderer.render_workspace_triage()
+
+    assert triage["source_health"]["available"] is False
+
+
+def test_render_signals_cached_across_bootstrap_and_triage():
+    """get_raw_file is called only once even if bootstrap and triage both render."""
+    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
+    gh = _make_github_mock(raw_file=_sample_so_json(regression=False))
+    renderer = Renderer(config, gh, _make_git_mock())
+
+    renderer.render_session_bootstrap()
+    renderer.render_workspace_triage()
+
+    assert gh.get_raw_file.call_count == 1
 
 
 def test_render_topic_index():

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -4,8 +4,10 @@ import json
 import pytest
 
 from agent_context_builder.signals import (
+    RepoSignals,
     SourceObservatorySignals,
     SourceSignal,
+    parse_repo_signals,
     parse_source_observatory_signals,
 )
 
@@ -48,10 +50,14 @@ def test_regressions_filter():
     assert so.regressions[0].source == "anac"
 
 
-def test_alerts_excludes_no_signal():
+def test_alerts_excludes_no_signal_and_regressions():
+    """alerts excludes both 'no signal' sources and sources already in regressions."""
     so = parse_source_observatory_signals(_sample_json())
-    assert len(so.alerts) == 1
-    assert so.alerts[0].signal_type == "health"
+    # ANAC is a regression (result == "regressione"), so it must NOT appear in alerts
+    assert len(so.alerts) == 0
+    # ANAC must appear in regressions instead
+    assert len(so.regressions) == 1
+    assert so.regressions[0].source == "anac"
 
 
 def test_all_stable_empty_filters():
@@ -80,3 +86,85 @@ def test_parse_missing_fields_uses_defaults():
     so = parse_source_observatory_signals(raw)
     assert so.captured_at == "unknown"
     assert so.signals[0].result == ""
+
+
+def test_alerts_excludes_regressions():
+    """A signal that is a regression must not also appear in alerts."""
+    so = parse_source_observatory_signals(_sample_json())
+    regression_sources = {s.source for s in so.regressions}
+    alert_sources = {s.source for s in so.alerts}
+    assert regression_sources.isdisjoint(alert_sources), (
+        f"Overlap between regressions and alerts: {regression_sources & alert_sources}"
+    )
+
+
+# --- parse_repo_signals / RepoSignals ---
+
+def _sample_repo_signals_json(signals: list[dict] | None = None) -> str:
+    return json.dumps({
+        "schema_version": "1",
+        "generated_at": "2026-04-16T10:00:00",
+        "repo": "dataciviclab/dataset-incubator",
+        "topic": "pipeline_state",
+        "signals": signals or [
+            {
+                "id": "irpef-comunale",
+                "status": "ok",
+                "label": "irpef-comunale (2022-2023)",
+                "detail": "single-source, mart SQL presente",
+                "action": "",
+            },
+            {
+                "id": "ispra-ru-base",
+                "status": "warn",
+                "label": "ispra-ru-base (2020-2023)",
+                "detail": "nessun mart SQL trovato",
+                "action": "aggiungere mart SQL",
+            },
+            {
+                "id": "broken-candidate",
+                "status": "error",
+                "label": "broken-candidate",
+                "detail": "struttura non riconosciuta",
+                "action": "verificare dataset.yml",
+            },
+        ],
+        "summary": {"ok": 1, "warn": 1, "error": 1},
+    })
+
+
+def test_parse_repo_signals_basic():
+    rs = parse_repo_signals(_sample_repo_signals_json())
+    assert rs.repo == "dataciviclab/dataset-incubator"
+    assert rs.topic == "pipeline_state"
+    assert rs.generated_at == "2026-04-16T10:00:00"
+    assert len(rs.signals) == 3
+
+
+def test_parse_repo_signals_actionable():
+    rs = parse_repo_signals(_sample_repo_signals_json())
+    actionable = rs.actionable
+    assert len(actionable) == 2
+    statuses = {s.status for s in actionable}
+    assert statuses == {"warn", "error"}
+
+
+def test_parse_repo_signals_all_ok():
+    raw = _sample_repo_signals_json([
+        {"id": "a", "status": "ok", "label": "a", "detail": "", "action": ""},
+    ])
+    rs = parse_repo_signals(raw)
+    assert rs.actionable == []
+
+
+def test_parse_repo_signals_invalid_json_raises():
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        parse_repo_signals("not json{")
+
+
+def test_parse_repo_signals_missing_fields_use_defaults():
+    raw = json.dumps({"signals": [{"id": "test"}]})
+    rs = parse_repo_signals(raw)
+    assert rs.generated_at == "unknown"
+    assert rs.signals[0].status == "ok"
+    assert rs.signals[0].label == "test"

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,82 @@
+"""Tests for signals module (parsing and data models)."""
+
+import json
+import pytest
+
+from agent_context_builder.signals import (
+    SourceObservatorySignals,
+    SourceSignal,
+    parse_source_observatory_signals,
+)
+
+
+def _sample_json(signals: list[dict] | None = None) -> str:
+    return json.dumps({
+        "captured_at": "2026-04-12",
+        "sources_checked": 3,
+        "signals": signals or [
+            {
+                "source": "istat_sdmx",
+                "protocol": "sdmx",
+                "signal_type": "no signal",
+                "result": "stabile",
+                "detail": "Stabile.",
+                "suggested_action": "nessuna",
+            },
+            {
+                "source": "anac",
+                "protocol": "ckan",
+                "signal_type": "health",
+                "result": "regressione",
+                "detail": "WAF attivo.",
+                "suggested_action": "monitorare",
+            },
+        ],
+    })
+
+
+def test_parse_returns_correct_counts():
+    so = parse_source_observatory_signals(_sample_json())
+    assert so.captured_at == "2026-04-12"
+    assert so.sources_checked == 3
+    assert len(so.signals) == 2
+
+
+def test_regressions_filter():
+    so = parse_source_observatory_signals(_sample_json())
+    assert len(so.regressions) == 1
+    assert so.regressions[0].source == "anac"
+
+
+def test_alerts_excludes_no_signal():
+    so = parse_source_observatory_signals(_sample_json())
+    assert len(so.alerts) == 1
+    assert so.alerts[0].signal_type == "health"
+
+
+def test_all_stable_empty_filters():
+    raw = _sample_json([
+        {
+            "source": "istat_sdmx",
+            "protocol": "sdmx",
+            "signal_type": "no signal",
+            "result": "stabile",
+            "detail": "ok",
+            "suggested_action": "nessuna",
+        }
+    ])
+    so = parse_source_observatory_signals(raw)
+    assert so.regressions == []
+    assert so.alerts == []
+
+
+def test_parse_invalid_json_raises():
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        parse_source_observatory_signals("not json{")
+
+
+def test_parse_missing_fields_uses_defaults():
+    raw = json.dumps({"signals": [{"source": "test"}]})
+    so = parse_source_observatory_signals(raw)
+    assert so.captured_at == "unknown"
+    assert so.signals[0].result == ""


### PR DESCRIPTION
## Summary

Integra il consumo di artifact JSON pre-calcolati da altri repo del Lab, via GitHub raw content (no checkout locale).

**Nuovi moduli:**
- `signals.py`: dataclass + parser per i due formati — `SourceObservatorySignals` (formato legacy SO) e `RepoSignals` (standard `repo-signals v1` definito in `schemas/repo-signals.md`)

**`GitHubCollector`:**
- aggiunge `get_raw_file(repo, path, ref)` — fetch da `raw.githubusercontent.com`, graceful degradation su 404/errore

**`Renderer`:**
- rimuove `LocalSignalsCollector` (era lettura da filesystem locale)
- aggiunge sezione **Source Health** in `session_bootstrap.md` e `source_health` in `workspace_triage.json` (da `source-observatory/data/catalog/catalog_signals.json`)
- aggiunge sezione **Pipeline State** in `session_bootstrap.md` e `pipeline_state` in `workspace_triage.json` (da `dataset-incubator/registry/pipeline_signals.json`)
- cache per-build con sentinel `_UNSET`: ogni file remoto viene fetchato una sola volta anche se bootstrap + triage vengono renderizzati entrambi

**`schemas/repo-signals.md`:** standard condiviso v1 per qualsiasi repo che voglia pubblicare segnali leggibili da ACB.

## Dipendenza

Questa PR dipende da dataciviclab/dataset-incubator#139 (`feat/pipeline-signals`) che deve mergiare su `main` prima che la sezione Pipeline State mostri dati reali invece di 404.

**Aperta in draft** in attesa del merge DI.

## Test plan

- [ ] `pytest` verde (test_signals.py + test_render.py aggiornati, incluso cache test)
- [ ] Dopo merge dataset-incubator#139: build locale mostra Pipeline State con dati reali
- [ ] Source Health mostra regressione ANAC da `catalog_signals.json` di SO

🤖 Generated with [Claude Code](https://claude.com/claude-code)