### PR TITLE
docs: usa generated come output locale Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ Lo script:
 - richiede un `WorkspaceRoot` esplicito
 - prova a usare `.venv314`, poi `.venv`, se presenti nella repo
 - esegue `agent-context build`
-- scrive gli artifact in `generated-local/`
+- scrive gli artifact in `generated/`
 
 I file da leggere in ordine sono:
 
-1. `generated-local/session_bootstrap.md`
-2. `generated-local/workspace_triage.json`
-3. `generated-local/topic_index.json`
+1. `generated/session_bootstrap.md`
+2. `generated/workspace_triage.json`
+3. `generated/topic_index.json`
 
 ### Solo GitHub (senza checkout locale)
 

--- a/codex-context.ps1
+++ b/codex-context.ps1
@@ -11,7 +11,7 @@ poi `.venv`, se presenti nella repo.
 param(
     [Parameter(Mandatory = $true)]
     [string]$WorkspaceRoot,
-    [string]$OutDir = "generated-local",
+    [string]$OutDir = "generated",
     [string]$ConfigPath = "dataciviclab.config.yml",
     [string]$VenvName = ""
 )


### PR DESCRIPTION
## Riepilogo

- allinea il wrapper `codex-context.ps1` a `generated/` come output locale standard
- aggiorna il `README.md` per usare `generated/` invece di `generated-local/`

## Contesto

Dopo il merge di `#8`, e' emerso che la distinzione `generated-local/` non era davvero necessaria: `generated/` e' gia' ignorata dal repo e non viene pushata in remoto.

## Verifica

Eseguito localmente su Windows:

```powershell
powershell -ExecutionPolicy Bypass -File .\codex-context.ps1 -WorkspaceRoot "C:\Users\matt\OneDrive\Desktop\Data_Projects\DataCivicLab"
```

Risultato:

- build completato con successo
- artifact generati in `generated/`
- `session_bootstrap.md`, `workspace_triage.json`, `topic_index.json` presenti

Closes #9
