### PR TITLE
fix: carica env locale per refresh context MCP

### DIFF
--- a/src/agent_context_builder/mcp_server.py
+++ b/src/agent_context_builder/mcp_server.py
@@ -15,6 +15,7 @@ Configuration via environment variables:
 """
 
 import os
+from pathlib import Path
 
 import requests
 from mcp.server.fastmcp import FastMCP
@@ -35,9 +36,86 @@ mcp = FastMCP(
 )
 
 
+_ENV_LOADED = False
+
+
+def _parse_env_line(line: str) -> tuple[str, str] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or "=" not in stripped:
+        return None
+    key, value = stripped.split("=", 1)
+    key = key.strip()
+    if not key:
+        return None
+    value = value.strip().strip('"').strip("'")
+    return key, value
+
+
+def _candidate_env_paths() -> list[Path]:
+    """Return .env candidates, from explicit config to nearby parent directories."""
+    explicit = os.environ.get("ACB_ENV_FILE", "").strip()
+    paths: list[Path] = []
+    if explicit:
+        paths.append(Path(explicit).expanduser())
+
+    starts = [Path.cwd(), Path(__file__).resolve()]
+    for start in starts:
+        current = start if start.is_dir() else start.parent
+        paths.extend(parent / ".env" for parent in [current] + list(current.parents))
+
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for path in paths:
+        resolved = path.resolve()
+        if resolved not in seen:
+            seen.add(resolved)
+            unique.append(resolved)
+    return unique
+
+
+def _load_dotenv_if_present() -> bool:
+    """Load local .env files without overriding variables already set by the host.
+
+    Lookup order:
+    1. `ACB_ENV_FILE`, when set.
+    2. `.env` from the current working directory upward.
+    3. `.env` from this module directory upward.
+
+    Partial `.env` files are allowed: the loader keeps checking later candidates
+    until at least one missing or blank variable has been filled.
+    """
+    global _ENV_LOADED
+    if _ENV_LOADED:
+        return True
+
+    loaded_any = False
+    for env_path in _candidate_env_paths():
+        if not env_path.exists():
+            continue
+        for line in env_path.read_text(encoding="utf-8").splitlines():
+            parsed = _parse_env_line(line)
+            if not parsed:
+                continue
+            key, value = parsed
+            if not os.environ.get(key):
+                os.environ[key] = value
+                loaded_any = True
+    if loaded_any:
+        _ENV_LOADED = True
+    return loaded_any
+
+
+def _get_env(name: str) -> str | None:
+    value = os.environ.get(name)
+    if value:
+        return value
+    _load_dotenv_if_present()
+    return os.environ.get(name)
+
+
 def _fetch(path: str) -> str:
     """Fetch a file from the context branch."""
-    token = os.environ.get("GITHUB_TOKEN")
+    token = _get_env("GITHUB_TOKEN")
     headers = {"Authorization": f"token {token}"} if token else {}
     response = requests.get(f"{_RAW_BASE}/{path}", headers=headers, timeout=10)
     response.raise_for_status()
@@ -69,7 +147,7 @@ def refresh_context() -> str:
     Richiede GITHUB_TOKEN con scope workflow.
     Gli artifact aggiornati saranno disponibili entro ~1 minuto.
     """
-    token = os.environ.get("GITHUB_TOKEN")
+    token = _get_env("GITHUB_TOKEN")
     if not token:
         return (
             "Errore: GITHUB_TOKEN non impostato. "

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -51,12 +51,74 @@ def test_topic_index_resource():
 
 def test_refresh_context_no_token(monkeypatch):
     """refresh_context returns error message when GITHUB_TOKEN not set."""
-    from agent_context_builder.mcp_server import refresh_context
+    import agent_context_builder.mcp_server as mcp_server
 
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    result = refresh_context()
+    monkeypatch.delenv("ACB_ENV_FILE", raising=False)
+    monkeypatch.setattr(mcp_server, "_ENV_LOADED", True)
+    result = mcp_server.refresh_context()
 
     assert "GITHUB_TOKEN" in result
+
+
+def test_refresh_context_loads_token_from_env_file(monkeypatch, tmp_path):
+    """refresh_context can use a local .env when the host does not export env vars."""
+    import agent_context_builder.mcp_server as mcp_server
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("GITHUB_TOKEN=file-token\n", encoding="utf-8")
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("ACB_ENV_FILE", str(env_file))
+    monkeypatch.setattr(mcp_server, "_ENV_LOADED", False)
+
+    with patch("agent_context_builder.mcp_server.requests.post") as mock_post:
+        mock_post.return_value = _mock_response("", status=204)
+        result = mcp_server.refresh_context()
+
+    assert "triggerato" in result.lower()
+    assert mock_post.call_args.kwargs["headers"]["Authorization"] == "token file-token"
+
+
+def test_refresh_context_loads_token_when_env_is_empty(monkeypatch, tmp_path):
+    """A blank inherited value should not block the local .env fallback."""
+    import agent_context_builder.mcp_server as mcp_server
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("GITHUB_TOKEN=file-token\n", encoding="utf-8")
+
+    monkeypatch.setenv("GITHUB_TOKEN", "")
+    monkeypatch.setenv("ACB_ENV_FILE", str(env_file))
+    monkeypatch.setattr(mcp_server, "_ENV_LOADED", False)
+
+    with patch("agent_context_builder.mcp_server.requests.post") as mock_post:
+        mock_post.return_value = _mock_response("", status=204)
+        result = mcp_server.refresh_context()
+
+    assert "triggerato" in result.lower()
+    assert mock_post.call_args.kwargs["headers"]["Authorization"] == "token file-token"
+
+
+def test_refresh_context_continues_after_partial_env(monkeypatch, tmp_path):
+    """A partial explicit .env should not prevent later candidates from filling tokens."""
+    import agent_context_builder.mcp_server as mcp_server
+
+    explicit_env = tmp_path / "partial.env"
+    explicit_env.write_text("ACB_BRANCH=context\n", encoding="utf-8")
+    workspace_env = tmp_path / ".env"
+    workspace_env.write_text("GITHUB_TOKEN=file-token\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("ACB_ENV_FILE", str(explicit_env))
+    monkeypatch.setattr(mcp_server, "_ENV_LOADED", False)
+
+    with patch("agent_context_builder.mcp_server.requests.post") as mock_post:
+        mock_post.return_value = _mock_response("", status=204)
+        result = mcp_server.refresh_context()
+
+    assert "triggerato" in result.lower()
+    assert mock_post.call_args.kwargs["headers"]["Authorization"] == "token file-token"
 
 
 def test_refresh_context_success(monkeypatch):


### PR DESCRIPTION
## Sintesi
- carica un `.env` locale in `agent-context-mcp` quando l'host MCP non esporta i segreti
- supporta `ACB_ENV_FILE` per host con working directory diversa dalla root del workspace
- mantiene prioritarie le variabili d'ambiente già esportate e riempie solo valori mancanti o vuoti

## Perché
`refresh_context` richiede `GITHUB_TOKEN` con scope `workflow`, ma alcuni host MCP avviano il server senza ereditare i valori del `.env` locale. In quel caso i tool di lettura funzionano, mentre `refresh_context` fallisce con `GITHUB_TOKEN non impostato` anche se il token esiste localmente.

## Verifica
- `PYTHONPATH=src /home/gabry/dev/dataciviclab-workspace/toolkit/.venv/bin/python -m pytest tests/test_mcp_server.py -q`
- smoke MCP locale dopo riavvio: `refresh_context` ha restituito `Build triggerato`
