### PR TITLE
Compatta documentazione di contesto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,252 +1,106 @@
 # agent-context-builder
 
-Genera contesto operativo compatto per gli agenti di [DataCivicLab](https://github.com/dataciviclab) a partire da GitHub e, opzionalmente, da checkout locali dei repo Lab.
-
-Sostituisce le letture larghe a inizio sessione con tre artifact mirati:
-
-| Artifact | Dimensione target | Consumato da |
-|---|---|---|
-| `session_bootstrap.md` | ~40 righe | agenti, umani |
-| `workspace_triage.json` | JSON compatto | agenti, MCP |
-| `topic_index.json` | JSON compatto | agenti, MCP |
-
-## Come funziona
-
-Il builder raccoglie da due fonti:
-
-- **GitHub** (sempre): PR, issue e discussion aperte per repo; non richiede checkout locale
-- **Git locale** (opzionale): branch corrente, stato dirty, commit non pushati per repo
-
-Gli artifact basati su GitHub vengono generati automaticamente ogni 6 ore dalla CI e pubblicati sul [branch `context`](../../tree/context). Chiunque abbia accesso al repo può consumarli senza eseguire il builder localmente.
+Genera contesto operativo compatto per agenti [DataCivicLab](https://github.com/dataciviclab)
+da GitHub e, se disponibile, dai checkout locali dei repo Lab.
 
 ## Artifact
 
-### `session_bootstrap.md`
+| Artifact | Target | Ruolo |
+|---|---|---|
+| `session_bootstrap.md` | ~40 righe | orientamento rapido per agenti e umani |
+| `workspace_triage.json` | JSON | PR, issue, discussion, warning, git state |
+| `topic_index.json` | JSON | lookup semantico per topic, repo e path |
 
-Orientamento rapido per agenti e umani:
+La CI aggiorna gli artifact GitHub-only ogni 6 ore sul branch `context`.
 
-```markdown
-# Session Bootstrap
+URL raw:
 
-**Generated**: 2026-04-14T20:00:00
-
-## Open PRs
-- [dataset-incubator#137](...): feat: bdap-lea clean respect raw schema
-
-## Open Discussions
-- [dataciviclab#42](...) [Civic Questions]: IRPEF comunale — cosa ci dice?
-
-## Local State
-**dataset-incubator**: `feat/bdap-lea-clean-respect-raw`
-
-## Topics
-- datasets
-- toolkit
-```
-
-### `workspace_triage.json`
-
-Riepilogo machine-readable consumato da agenti e dall'MCP `dataciviclab-state`:
-
-```json
-{
-  "open_prs": 2,
-  "prs": [...],
-  "open_issues": 14,
-  "issues": [...],
-  "open_discussions": 3,
-  "discussions": [...],
-  "git_state": {
-    "dataset-incubator": { "available": true, "current_branch": "feat/...", "dirty": false }
-  },
-  "warnings": [...]
-}
-```
-
-### `topic_index.json`
-
-Lookup semantico per topic — repo rilevanti, path, prossimo passo suggerito:
-
-```json
-{
-  "topics": {
-    "datasets": {
-      "summary": "Incubazione dataset e analisi pubblicate",
-      "repos": ["dataset-incubator", "dataciviclab"],
-      "paths": ["dataset-incubator/", "dataciviclab/analisi/"],
-      "next": "Consulta dataset-incubator/PROMOTION_CHECKLIST.md"
-    }
-  }
-}
+```text
+https://raw.githubusercontent.com/dataciviclab/agent-context-builder/context/session_bootstrap.md
+https://raw.githubusercontent.com/dataciviclab/agent-context-builder/context/workspace_triage.json
+https://raw.githubusercontent.com/dataciviclab/agent-context-builder/context/topic_index.json
 ```
 
 ## Utilizzo
 
-### Profili operativi
+### Shared mode via MCP
 
-Il workflow è stato verificato in due modalità distinte:
+Usa `agent-context-mcp` / `dataciviclab-context` per leggere gli artifact remoti.
+Non richiede checkout locale.
 
-- **Claude = shared mode**: usa `agent-context-mcp` e legge gli artifact pubblicati sul branch `context`
-- **Codex = local mode**: esegue il builder in locale con `--workspace-root` e legge gli artifact appena generati
-
-Per Claude, la configurazione MCP consigliata è quella del server `agent-context-mcp`.
-
-Per Codex, il comando quotidiano consigliato su Windows è:
-
-```powershell
-.\codex-context.ps1 -WorkspaceRoot "C:\path\to\dataciviclab-workspace"
+```bash
+pip install -e ".[mcp]"
+agent-context-mcp
 ```
 
-Lo script:
+Risorse MCP:
 
-- imposta `PYTHONIOENCODING=utf-8`
-- neutralizza `CURL_CA_BUNDLE` se ereditato dall'ambiente
-- richiede un `WorkspaceRoot` esplicito
-- prova a usare `.venv314`, poi `.venv`, se presenti nella repo
-- esegue `agent-context build`
-- scrive gli artifact in `generated/`
+| URI | Contenuto |
+|---|---|
+| `context://session_bootstrap` | markdown di avvio sessione |
+| `context://workspace_triage` | triage machine-readable |
+| `context://topic_index` | indice topic |
 
-I file da leggere in ordine sono:
+Tool:
 
-1. `generated/session_bootstrap.md`
-2. `generated/workspace_triage.json`
-3. `generated/topic_index.json`
+| Tool | Uso |
+|---|---|
+| `refresh_context` | triggera build CI; richiede `GITHUB_TOKEN` con scope `workflow` |
 
-### Solo GitHub (senza checkout locale)
+### Local mode
+
+Esegue il builder localmente per includere lo stato git (branch, dirty).
 
 ```bash
 pip install -e .
-agent-context build --config dataciviclab.config.yml --out generated/
-```
-
-PR e issue vengono dalla REST API di GitHub (accesso non autenticato, solo repo pubblici).
-Le discussion richiedono un token (la GraphQL API di GitHub richiede sempre autenticazione).
-
-### Con checkout locale
-
-```bash
-export DATACIVICLAB_WORKSPACE=~/dev/dataciviclab-workspace
-agent-context build --config dataciviclab.config.yml --out generated/
-```
-
-Oppure passato direttamente:
-
-```bash
 agent-context build \
   --config dataciviclab.config.yml \
   --out generated/ \
   --workspace-root ~/dev/dataciviclab-workspace
 ```
 
-### Con discussion
+Windows:
 
-```bash
-export GITHUB_TOKEN=ghp_...
-agent-context build --config dataciviclab.config.yml --out generated/
+```powershell
+.\codex-context.ps1 -WorkspaceRoot "C:\path\to\dataciviclab-workspace"
 ```
 
-Quando `GITHUB_TOKEN` è impostato, le discussion vengono raccolte automaticamente insieme a PR e issue.
+Il wrapper imposta UTF-8, neutralizza `CURL_CA_BUNDLE` ereditato e usa `.venv314`
+o `.venv` se presenti.
 
-## CI — pubblicazione automatica degli artifact
+## Configurazione (`dataciviclab.config.yml`)
 
-Il workflow [`build-context`](.github/workflows/build-context.yml) gira ogni 6 ore e a ogni push su `main`. Genera gli artifact in modalità GitHub-only e li pubblica con un force-push sul branch `context`.
-
-Gli artifact sono disponibili a:
-
-```
-https://raw.githubusercontent.com/dataciviclab/agent-context-builder/context/session_bootstrap.md
-https://raw.githubusercontent.com/dataciviclab/agent-context-builder/context/workspace_triage.json
-https://raw.githubusercontent.com/dataciviclab/agent-context-builder/context/topic_index.json
-```
-
-L'MCP `dataciviclab-state` legge da questi URL per servire il contesto agli agenti senza richiedere esecuzione locale.
-
-## Configurazione
-
-`dataciviclab.config.yml` alla root è la config attiva del Lab. Definisce quali repo e topic monitorare.
-
-Per usare il builder con un'altra organizzazione, copia `examples/config.template.yml` e adattalo.
-
-Campi principali:
+Definisce organizzazione, repo e topic da monitorare.
 
 ```yaml
 github_org: dataciviclab
-
 repos:
   - dataset-incubator
   - dataciviclab
-
 topics:
   datasets:
-    summary: Incubazione dataset e analisi pubblicate
+    summary: Incubazione dataset
     repos: [dataset-incubator, dataciviclab]
     paths: [dataset-incubator/, dataciviclab/analisi/]
-    next: Consulta PROMOTION_CHECKLIST.md
 ```
 
-`workspace_root` è volutamente assente dalla config — si imposta via `--workspace-root` o env var `DATACIVICLAB_WORKSPACE`, per macchina.
+`workspace_root` resta fuori dalla config: usare `--workspace-root` o
+`DATACIVICLAB_WORKSPACE`. `GITHUB_TOKEN` serve per GitHub Discussions e refresh CI.
+
+Variabili MCP utili: `ACB_REPO`, `ACB_BRANCH`, `ACB_ENV_FILE`.
 
 ## Degradazione controllata
 
-Il builder non crasha mai per dati mancanti:
+Il builder non deve crashare per contesto parziale:
 
 | Condizione | Comportamento |
 |---|---|
-| Rate limit GitHub / 403 | `open_prs: null`, errori in `github_fetch_errors` |
-| Repo privato (404, senza token) | repo saltato, errore registrato |
-| Nessun token | discussion saltate con avviso |
-| Repo non clonato localmente | `available: false, reason: path_not_found` |
-| Path locale non è un repo git | `available: false, reason: not_git_repo` |
-| `--workspace-root` non impostato | `available: false, reason: local_disabled` |
-
-## MCP Server
-
-Il repo include un server MCP pubblico che espone i tre artifact come risorse leggibili dagli agenti senza richiedere esecuzione locale del builder.
-
-### Installazione
-
-```bash
-pip install -e ".[mcp]"
-```
-
-### Avvio
-
-```bash
-agent-context-mcp
-```
-
-### Risorse esposte
-
-| URI | Contenuto |
-|---|---|
-| `context://session_bootstrap` | `session_bootstrap.md` dal branch `context` |
-| `context://workspace_triage` | `workspace_triage.json` dal branch `context` |
-| `context://topic_index` | `topic_index.json` dal branch `context` |
-
-### Tool
-
-| Tool | Descrizione |
-|---|---|
-| `refresh_context` | Triggera un nuovo build CI (richiede `GITHUB_TOKEN` con scope `workflow`) |
-
-### Configurazione Claude Code
-
-```json
-{
-  "mcpServers": {
-    "dataciviclab-context": {
-      "command": "agent-context-mcp",
-      "env": {
-        "GITHUB_TOKEN": "<token-opzionale-per-refresh>"
-      }
-    }
-  }
-}
-```
-
-Le risorse sono aggiornate automaticamente ogni 6 ore dalla CI. Il token è opzionale per la sola lettura; serve solo per `refresh_context`.
-
-Le variabili d'ambiente `ACB_REPO` e `ACB_BRANCH` permettono di puntare a un fork o a un branch diverso.
+| rate limit / 403 GitHub | campi `null`, errore in JSON |
+| repo privato senza token | repo saltato, warning registrato |
+| nessun token | discussion saltate |
+| repo locale assente | `available: false`, `reason: path_not_found` |
+| path non git | `available: false`, `reason: not_git_repo` |
+| local mode non attivo | `available: false`, `reason: local_disabled` |
 
 ## Sviluppo
 
@@ -256,13 +110,8 @@ pytest
 ruff check .
 ```
 
-## Roadmap
+## Roadmap & Licenza
 
-- **P0** — MVP: bootstrap, triage, topic index, git collector, GitHub Actions ✓
-- **P0.5** — MCP server pubblico: risorse read-only + tool refresh ✓
-- **P1** — Schema JSON per stabilità output; integrazione `dataciviclab-state` MCP locale
-- **P2** — Script wrapper locale; fast path in `AGENTS.md`
-
-## Licenza
-
-MIT
+- **P1**: schema JSON stabile e integrazione `dataciviclab-state`.
+- **P2**: session brief/local health più compatti.
+- **Licenza**: MIT

--- a/README.md
+++ b/README.md
@@ -127,6 +127,6 @@ ruff check .
 
 ## Roadmap & Licenza
 
-- **P1**: schema JSON stabile e integrazione `dataciviclab-state`.
+- **P1**: schema JSON stabile per artifact consumabili da MCP e agenti.
 - **P2**: session brief/local health più compatti.
 - **Licenza**: MIT

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ topics:
 `workspace_root` resta fuori dalla config: usare `--workspace-root` o
 `DATACIVICLAB_WORKSPACE`. `GITHUB_TOKEN` serve per GitHub Discussions e refresh CI.
 
-Variabili MCP utili: `ACB_REPO`, `ACB_BRANCH`, `ACB_ENV_FILE`.
+Variabili MCP utili: `ACB_REPO`, `ACB_BRANCH`.
 
 ## Degradazione controllata
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ Tool:
 |---|---|
 | `refresh_context` | triggera build CI; richiede `GITHUB_TOKEN` con scope `workflow` |
 
+Esempio `settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "dataciviclab-context": {
+      "command": "agent-context-mcp",
+      "env": {
+        "GITHUB_TOKEN": "<opzionale-per-refresh>"
+      }
+    }
+  }
+}
+```
+
 ### Local mode
 
 Esegue il builder localmente per includere lo stato git (branch, dirty).

--- a/workflows/lab-check.md
+++ b/workflows/lab-check.md
@@ -1,6 +1,6 @@
 ---
 name: lab-check
-description: Skill invocabile come /lab-check per controllare le novità e lo stato del DataCivicLab tramite il server MCP dataciviclab-context.
+description: Check rapido delle novità e dello stato del Lab tramite MCP dataciviclab-context.
 license: MIT
 metadata:
   version: "0.2"
@@ -10,117 +10,49 @@ metadata:
 
 # Workflow: lab-check
 
-Workflow canonico di `agent-context-builder`.
-Versione: 0.2 - 2026-04-16
-
-## Obiettivo di fase
-
-Fornire agli agenti e ai contributor umani una procedura rapida per leggere lo stato strutturato del Lab (novità, blocchi, PR aperte, issue rilevanti) usando i tool MCP del builder di contesto.
-
-Questo workflow serve a:
-
-- orientarsi rapidamente nel Lab e nei task aperti
-- individuare i repository o le discussion che richiedono attenzione prima di lavorare
-- fare il punto e definire le priorità della sessione
-
-Non serve a:
-
-- estrarre repository o dataset per l'elaborazione diretta dal workspace (è puramente per contesto)
-- sostituire skill operative di PR e file editing
-- ispezionare il contenuto dettagliato del codice di una determinata applicazione
-
-## Profilo operativo coperto
-
-Questo workflow copre il profilo **shared-mode via MCP** (`dataciviclab-context`).
-
-Il Lab ha due profili operativi distinti:
-
-- **Shared-mode (MCP)** — Claude Code e agenti che leggono il contesto via server MCP. Questo è il profilo che questo workflow descrive.
-- **Local-mode** — Codex o agenti con accesso diretto al git workspace locale. In questo caso il check dello stato parte dal git state reale, non dai tool MCP.
-
-Se stai lavorando in local-mode, questo workflow non è il tuo percorso primario.
+Obiettivo: orientarsi rapidamente su PR, issue, discussion, topic e blocchi operativi via MCP.
 
 ## Quando usarlo
 
-Usalo quando hai già:
+- Inizio sessione senza quadro chiaro.
+- Controllo warning, PR, issue o discussion per una macro-area.
+- Triage tematico prima di aprire file o repo specifici.
+- **Non usare** per task tecnici isolati, build dati o editing di codice.
 
-- iniziato una nuova sessione e non hai chiaro il contesto generale
-- devi controllare se ci sono issue aperte, discussion o warning per una macro-area del Lab
-- l'MCP server `dataciviclab-context` attivo e vuoi un quadro aggiornato
+## Profilo operativo
 
-Non usarlo quando:
+- **Shared-mode MCP**: percorso primario di questo workflow.
+- **Local-mode git**: se hai il workspace locale, usa anche stato git reale e report locali.
 
-- sei già inquadrato su un task operativo piccolo in un singolo repo (es. fix di uno script in `toolkit`)
-- devi compilare layer puliti o mart (usa le skill specifiche o tool in `toolkit`)
-
-## Preconditions minime
-
-- Server MCP `dataciviclab-context` avviato e accessibile all'agente.
-- Intento esplorativo / di status check ben definito.
-
-Nel dubbio:
-- se sai già su che problema lavorare, salta questo check e vai dritto al file/issue.
-
-## Stop rules
-
-Fermati e non forzare il workflow quando:
-
-- l'agente o il server non riescono a ottenere i json o le dipendenze per rispondere ai tool
-- il `session_bootstrap` restituisce un contesto obsoleto per motivi tecnici
+Precondizione: server MCP `dataciviclab-context` accessibile.
 
 ## Passi canonici
 
-### 1. Avvio sessione di base
+1. **session_bootstrap**: prima chiamata. Leggi repo attivi, PR, issue, discussion e warning.
+2. **topic_index**: usalo se la sessione è tematica e serve capire dove guardare.
+3. **workspace_triage**: usalo se il problema riguarda stato incrociato di repo o issue.
+4. **refresh_context**: solo se i dati sono palesemente obsoleti dopo merge/push. Attendere la CI.
 
-Usa il tool `mcp__dataciviclab-context__session_bootstrap`.
-- **Cosa fare:** Chiamare il tool via MCP.
-- **Cosa controllare:** Leggere l'elenco dei repo attivi, le PR aperte, le discussion recenti e lo stato locale rilevante. 
-- **Cosa evitare:** Ignorare blocchi di stato chiari segnalati nell'output.
+## Stop rules ed errori
 
-### 2. Ispezione dei Topic e Triage
+- Fermati se i tool MCP falliscono o restituiscono JSON non leggibile.
+- Non usare `refresh_context` a ogni sessione: e' eccezione, non default.
+- Non scrivere commenti o aprire issue solo da triage: valida l'attualità.
+- Ricorda il lag fisiologico tra GitHub/CI e stato git locale.
 
-In base all'obiettivo operativo ci sono due percorsi:
+## Output minimo
 
-- Se la sessione è tematica (es. "scouting su appalti" o topic affine):
-  Usa `mcp__dataciviclab-context__topic_index` per capire dove guardare e valutare le path specifiche pertinenti in giro per il lab.
-- Se si deve gestire lo stato incrociato di un repository:
-  Usa `mcp__dataciviclab-context__workspace_triage` per ottenere le informazioni su git status, issue e le discussioni aggregate.
+Il workflow è completo quando hai uno di questi esiti:
 
-## Azioni opzionali e Troubleshooting
+- artifact identificato: PR, issue, discussion o topic;
+- nessuna novità critica: puoi continuare il task già noto;
+- contesto bloccato: serve refresh o debug MCP.
 
-Se il contesto restituito è palesemente obsoleto rispetto a merge o push appena effettuati, puoi invocare `mcp__dataciviclab-context__refresh_context` per triggerare una rebuild della CI.
-Attenzione: questo step impiegherà ~1 minuto prima di produrre un output aggiornato e **non** deve essere eseguito di default ogni volta, ma solo come eccezione.
+## Stati finali
+- `checked`: Orientamento completato, pronto al lavoro.
+- `waiting-for-refresh`: Rebuild CI in corso.
+- `blocked-on-context`: Errore tecnico dei tool context.
 
-## Errori tipici
-
-- Entrare in una catena esplorativa lunga senza aver prima richiesto il `session_bootstrap`.
-- Confondere triage su issue con la scrittura di commenti diretti sulle issue prima di validarne l'attualità.
-- Ignorare la cache di GitHub in cui pesca il contesto; ricordati che può laggare rispetto allo stato git locale ultimissimo.
-
-## Output minimo atteso
-
-L'esito del workflow è considerato completo se l'agente o il contributor ha ottenuto un quadro chiaro sullo stato del Lab e sa cosa fare (o non fare) nella sessione.
-
-Gli esiti validi sono tutti questi:
-
-- Ha identificato un artifact (PR, issue, discussion) su cui concentrarsi.
-- Ha constatato che non ci sono novità critiche e può proseguire sul task già in corso.
-- Ha deciso di non fare nulla ora e ha una motivazione chiara.
-
-Non è richiesta una classificazione formale dell'artifact né la selezione obbligatoria di un "prossimo passo".
-
-## Definition of done
-
-- Il report dello stato Lab è stato interpretato correttamente.
-- Il focus della sessione è stato sbloccato o ristretto al passo immediatamente successivo da farsi nel workspace di interesse.
-
-## Stati finali ammessi
-
-- `checked` (l'orientamento è completato)
-- `waiting-for-refresh` (trigger di aggiornamento fatto, serve attendere la CI)
-- `blocked-on-context` (tool fallisce)
-
-## Dove orientarsi
-
-- README del repo `/agent-context-builder`
-- [dataciviclab-context MCP] per il backend esecutivo legato all'esposizione
+## Riferimenti
+- README `agent-context-builder`
+- MCP `dataciviclab-context`

--- a/workflows/lab-check.md
+++ b/workflows/lab-check.md
@@ -22,7 +22,7 @@ Obiettivo: orientarsi rapidamente su PR, issue, discussion, topic e blocchi oper
 ## Profilo operativo
 
 - **Shared-mode MCP**: percorso primario di questo workflow.
-- **Local-mode git**: se hai il workspace locale, usa anche stato git reale e report locali.
+- **Local-mode git**: se hai il workspace locale, leggi stato git direttamente (`git status`, branch, dirty) — il triage MCP resta utile per PR/issue/discussion, non per lo stato dei branch locali. Non invocare `refresh_context` se il tuo quadro viene già dal git locale.
 
 Precondizione: server MCP `dataciviclab-context` accessibile.
 


### PR DESCRIPTION
## Cosa cambia

- Compatta `README.md`: rimuove esempi verbosi, mantiene artifact, shared/local mode, MCP, CI, degradazione controllata e URL raw
- Compatta `workflows/lab-check.md`: mantiene passi canonici, stop rules, stati finali e riferimenti; rimuove sezioni ridondanti

## Perché

Riduzione carico di contesto sui documenti operativi. `agent-context-builder` deve essere leggibile a inizio sessione senza perdere i dettagli necessari per MCP, CI e local mode.

## Verifiche

- `git diff --check`
- `python3 -m compileall -q src tests`
- `pytest -q` → 47 passed

Nota: `ruff check .` segnala 5 issue preesistenti nei test (`E501`, import non usati) — fuori scope di questa PR.