### PR TITLE
Migliora bootstrap PR e warning GitHub

### DIFF
--- a/src/agent_context_builder/github.py
+++ b/src/agent_context_builder/github.py
@@ -15,6 +15,7 @@ class PR:
     repo: str
     url: str
     state: str = "open"
+    author: str = ""
 
 
 @dataclass
@@ -43,6 +44,21 @@ class GitHubCollector:
         self.base_url = "https://api.github.com"
         # Populated by get_prs/get_issues — maps "<repo>:prs" or "<repo>:issues" to error message
         self.fetch_errors: dict[str, str] = {}
+
+    def collector_warning(self) -> str | None:
+        """Return a human-readable warning if fetch errors suggest rate-limit or auth degradation."""
+        if not self.fetch_errors:
+            return None
+        msgs = " ".join(self.fetch_errors.values()).lower()
+        if "403" in msgs or "rate limit" in msgs or "secondary rate" in msgs:
+            return (
+                "GitHub rate-limit or auth error "
+                f"({len(self.fetch_errors)} collector(s) affected) - data may be incomplete"
+            )
+        return (
+            f"GitHub fetch error ({len(self.fetch_errors)} collector(s) affected) "
+            "- data may be incomplete"
+        )
 
     def get_prs(self, repos: list[str], state: str = "open") -> list[PR]:
         """Get open PRs across repos.
@@ -100,6 +116,7 @@ class GitHubCollector:
                     repo=repo,
                     url=item["html_url"],
                     state=item["state"],
+                    author=item.get("user", {}).get("login", ""),
                 )
             )
         return prs

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -74,14 +74,21 @@ class Renderer:
         lines.append("")
         prs = self.github_collector.get_prs(self.config.repos)
         github_errors = self.github_collector.fetch_errors
-        if github_errors:
-            lines.append(
-                f"> **GitHub unavailable** — {len(github_errors)} fetch error(s);"
-                " PR/issue counts may be incomplete"
-            )
+        collector_warn = self.github_collector.collector_warning()
+        if collector_warn:
+            lines.append(f"> **Warning**: {collector_warn}")
         if prs:
-            for pr in prs[:10]:  # Limit to first 10
+            _DEPENDABOT = {"dependabot[bot]", "dependabot"}
+            feature_prs = [pr for pr in prs if pr.author not in _DEPENDABOT]
+            dep_prs = [pr for pr in prs if pr.author in _DEPENDABOT]
+            for pr in feature_prs[:10]:
                 lines.append(f"- [{pr.repo}#{pr.number}]({pr.url}): {pr.title}")
+            if dep_prs:
+                lines.append(
+                    f"- **Dependabot**: {len(dep_prs)} bump PR(s) - "
+                    + ", ".join(f"[#{pr.number}]({pr.url})" for pr in dep_prs[:2])
+                    + (" ..." if len(dep_prs) > 2 else "")
+                )
         elif not github_errors:
             lines.append("*No open PRs*")
         lines.append("")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -8,7 +8,7 @@ import json
 from agent_context_builder.config import Config
 from agent_context_builder.discussions import Discussion, DiscussionCollector
 from agent_context_builder.git_local import GitLocalCollector, GitState
-from agent_context_builder.github import GitHubCollector
+from agent_context_builder.github import GitHubCollector, PR
 from agent_context_builder.render import Renderer
 
 _UNAVAILABLE = GitState(available=False, reason="path_not_found", dirty=None, current_branch=None)
@@ -36,6 +36,21 @@ def _make_github_mock(prs=None, issues=None, fetch_errors=None, raw_file=None):
     m.get_issues.return_value = issues or []
     m.fetch_errors = fetch_errors or {}
     m.get_raw_file.return_value = raw_file  # None by default = signal fetch fails gracefully
+    errors = fetch_errors or {}
+    if errors:
+        msgs = " ".join(errors.values()).lower()
+        if "403" in msgs or "rate limit" in msgs:
+            m.collector_warning.return_value = (
+                "GitHub rate-limit or auth error "
+                f"({len(errors)} collector(s) affected) - data may be incomplete"
+            )
+        else:
+            m.collector_warning.return_value = (
+                f"GitHub fetch error ({len(errors)} collector(s) affected) "
+                "- data may be incomplete"
+            )
+    else:
+        m.collector_warning.return_value = None
     return m
 
 
@@ -77,8 +92,32 @@ def test_render_session_bootstrap_github_error():
     )
     bootstrap = renderer.render_session_bootstrap()
 
-    assert "GitHub unavailable" in bootstrap
+    assert "rate-limit" in bootstrap
     assert "No open PRs" not in bootstrap
+
+
+def test_render_session_bootstrap_groups_dependabot_prs():
+    """Bootstrap keeps Dependabot PRs compact and leaves feature PRs visible."""
+    config = Config(
+        workspace_root=Path("/tmp/test"),
+        github_org="test-org",
+        repos=["repo1"],
+    )
+    prs = [
+        PR(1, "feat: improve context", "repo1", "https://example.test/pr/1", author="gabry"),
+        PR(2, "chore(deps): bump package", "repo1", "https://example.test/pr/2", author="dependabot[bot]"),
+        PR(3, "chore(deps): bump action", "repo1", "https://example.test/pr/3", author="dependabot[bot]"),
+    ]
+    renderer = Renderer(
+        config,
+        _make_github_mock(prs=prs),
+        _make_git_mock({"repo1": _UNAVAILABLE}),
+    )
+    bootstrap = renderer.render_session_bootstrap()
+
+    assert "feat: improve context" in bootstrap
+    assert "**Dependabot**: 2 bump PR(s)" in bootstrap
+    assert "chore(deps): bump package" not in bootstrap
 
 
 def test_render_workspace_triage():


### PR DESCRIPTION
## Cosa cambia

- aggiunge `collector_warning()` al collector GitHub per segnalare rate-limit, auth error o degrado fetch
- separa le PR Dependabot dal feature work nel `session_bootstrap`
- mostra solo conteggio + prime 2 PR Dependabot, evitando che oscurino le PR operative
- aggiunge test sul warning GitHub e sul raggruppamento Dependabot

## Perché

Il bootstrap resta più leggibile quando ci sono molti bump automatici e segnala chiaramente quando i dati GitHub possono essere incompleti.

## Review locale

Nessun finding bloccante. Ho solo sostituito simboli unicode nel messaggio di warning con testo ASCII per restare coerenti col repo.

## Verifiche

- `git diff --check`
- `python3 -m pytest -q` -> 48 passed
