### PR TITLE
Consume Source Observatory inventory summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,17 @@ topics:
     summary: Incubazione dataset
     repos: [dataset-incubator, dataciviclab]
     paths: [dataset-incubator/, dataciviclab/analisi/]
+
+# Optional: enable only after source-observatory publishes a stable summary artifact.
+# source_catalog_summary_path: data/catalog_inventory/generated/source_catalog_summary.json
 ```
 
 `workspace_root` resta fuori dalla config: usare `--workspace-root` o
 `DATACIVICLAB_WORKSPACE`. `GITHUB_TOKEN` serve per GitHub Discussions e refresh CI.
+
+`source_catalog_summary_path` è un opt-in verso `source-observatory`: se non è
+configurato, ACB non prova a leggere inventari sorgenti e non aggiunge la sezione
+`Source Inventory` agli artifact generati.
 
 Variabili MCP utili: `ACB_REPO`, `ACB_BRANCH`.
 

--- a/examples/config.template.yml
+++ b/examples/config.template.yml
@@ -13,6 +13,10 @@ repos:
   - repo-two
   - repo-three
 
+# Optional source-observatory inventory artifact. Leave unset until your org publishes
+# a stable source_catalog_summary.json and wants Source Inventory in generated outputs.
+# source_catalog_summary_path: data/catalog_inventory/generated/source_catalog_summary.json
+
 # Topics provide semantic grouping for faster agent orientation.
 # Each topic maps to a set of repos and paths, with a summary and suggested next step.
 topics:

--- a/src/agent_context_builder/config.py
+++ b/src/agent_context_builder/config.py
@@ -31,6 +31,13 @@ class Config(BaseModel):
         default_factory=list, description="Primary repos to monitor"
     )
     topics: dict[str, Topic] = Field(default_factory=dict, description="Topic index")
+    source_catalog_summary_path: Optional[str] = Field(
+        None,
+        description=(
+            "Optional source-observatory raw artifact path for source inventory. "
+            "When unset, source inventory rendering is disabled."
+        ),
+    )
 
     @classmethod
     def from_yaml(cls, path: Path) -> "Config":

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -9,9 +9,11 @@ from .github import GitHubCollector, PR
 from .git_local import GitLocalCollector, GitState
 from .signals import (
     RepoSignals,
+    SourceCatalogSummary,
     SourceObservatorySignals,
     parse_repo_signals,
     parse_source_observatory_signals,
+    parse_source_catalog_summary,
 )
 
 
@@ -46,6 +48,7 @@ class Renderer:
         self.fixed_timestamp = fixed_timestamp or datetime.now().isoformat()
         # Cache for remote signal fetches — avoids double requests within one build
         self._so_signals_cache: SourceObservatorySignals | None | type[_UNSET] = _UNSET
+        self._source_catalog_cache: SourceCatalogSummary | None | type[_UNSET] = _UNSET
         self._di_signals_cache: RepoSignals | None | type[_UNSET] = _UNSET
 
     def render_session_bootstrap(self) -> str:
@@ -126,6 +129,11 @@ class Renderer:
                 lines.append(f"- {topic_name}")
             lines.append("")
 
+        # Source inventory is opt-in until source-observatory publishes a stable artifact.
+        if self.config.source_catalog_summary_path:
+            source_catalog = self._fetch_source_catalog_summary()
+            lines += self._render_source_inventory_section(source_catalog)
+
         # Source health (only issues — skip stable sources)
         so = self._fetch_source_observatory_signals()
         lines += self._render_source_health_section(so)
@@ -152,6 +160,93 @@ class Renderer:
             result = None
         self._so_signals_cache = result
         return result
+
+    def _fetch_source_catalog_summary(self) -> SourceCatalogSummary | None:
+        if self._source_catalog_cache is not _UNSET:
+            return self._source_catalog_cache  # type: ignore[return-value]
+
+        path = self.config.source_catalog_summary_path
+        if not path:
+            self._source_catalog_cache = None
+            return None
+
+        raw = self.github_collector.get_raw_file("source-observatory", path)
+        if raw is None:
+            self._source_catalog_cache = None
+            return None
+        try:
+            result = parse_source_catalog_summary(raw)
+        except ValueError as exc:
+            self.github_collector.fetch_errors[
+                "source-observatory:source_catalog_summary"
+            ] = (
+                f"{path}: {exc}"
+            )
+            result = None
+        self._source_catalog_cache = result
+        return result
+
+    def _render_source_inventory_section(
+        self, source_catalog: SourceCatalogSummary | None
+    ) -> list[str]:
+        lines = []
+        lines.append("## Source Inventory")
+        lines.append("")
+        if source_catalog is None:
+            err = self.github_collector.fetch_errors.get(
+                "source-observatory:source_catalog_summary"
+            )
+            if err:
+                lines.append(f"> *source catalog summary unavailable — {err}*")
+            else:
+                lines.append("> *source catalog summary unavailable*")
+            lines.append("")
+            return lines
+
+        source_count = len(source_catalog.sources)
+        candidate_count = len(source_catalog.intake_candidates)
+        if source_count == 0 and candidate_count == 0:
+            lines.append(f"*No source inventory entries* (as of {source_catalog.captured_at})")
+            lines.append("")
+            return lines
+
+        for src in source_catalog.sources[:5]:
+            parts = [f"- **{src.source_id}**"]
+            if src.protocol:
+                parts.append(f"[{src.protocol}]")
+            if src.items is not None:
+                item_text = f"{src.items} items"
+                if src.titled is not None:
+                    item_text += f", {src.titled} titled"
+                parts.append(f": {item_text}")
+            elif src.titled is not None:
+                parts.append(f": {src.titled} titled")
+            if src.inventory_method:
+                parts.append(f"(`{src.inventory_method}`)")
+            if src.status:
+                parts.append(f"status: {src.status}")
+            if src.api_base_url:
+                parts.append(f"<{src.api_base_url}>")
+            lines.append(" ".join(parts))
+
+        if source_count > 5:
+            lines.append(f"- *…and {source_count - 5} more sources*")
+
+        if candidate_count:
+            lines.append(f"  *{candidate_count} intake candidate(s); top entries:*")
+            for candidate in source_catalog.intake_candidates[:3]:
+                span = ""
+                if candidate.year_min is not None or candidate.year_max is not None:
+                    span = f" ({candidate.year_min or '?'}-{candidate.year_max or '?'})"
+                score = candidate.intake_score if candidate.intake_score is not None else "n/d"
+                lines.append(
+                    f"  - **{candidate.source_id}**: {candidate.title}"
+                    f" [{score}]{span}"
+                )
+
+        lines.append(f"  *(captured {source_catalog.captured_at})*")
+        lines.append("")
+        return lines
 
     def _render_source_health_section(
         self, so: SourceObservatorySignals | None
@@ -259,6 +354,8 @@ class Renderer:
             "source_health": self._build_source_health_dict(),
             "pipeline_state": self._build_pipeline_state_dict(),
         }
+        if self.config.source_catalog_summary_path:
+            triage["source_inventory"] = self._build_source_inventory_dict()
         return triage
 
     def _build_source_health_dict(self) -> dict[str, Any]:
@@ -295,6 +392,46 @@ class Renderer:
                 }
                 for s in so.alerts
             ],
+        }
+
+    def _build_source_inventory_dict(self) -> dict[str, Any]:
+        source_catalog = self._fetch_source_catalog_summary()
+        if source_catalog is None:
+            return {
+                "available": False,
+                "errors": {
+                    k: v for k, v in self.github_collector.fetch_errors.items()
+                    if "source_catalog_summary" in k
+                },
+            }
+        return {
+            "available": True,
+            "captured_at": source_catalog.captured_at,
+            "sources": [
+                {
+                    "source_id": s.source_id,
+                    "protocol": s.protocol,
+                    "items": s.items,
+                    "titled": s.titled,
+                    "inventory_method": s.inventory_method,
+                    "api_base_url": s.api_base_url,
+                    "status": s.status,
+                }
+                for s in source_catalog.sources
+            ],
+            "intake_candidates": [
+                {
+                    "source_id": c.source_id,
+                    "item_name": c.item_name,
+                    "title": c.title,
+                    "granularity": c.granularity,
+                    "year_min": c.year_min,
+                    "year_max": c.year_max,
+                    "intake_score": c.intake_score,
+                }
+                for c in source_catalog.intake_candidates[:10]
+            ],
+            "summary": source_catalog.summary,
         }
 
     def _fetch_di_pipeline_signals(self) -> RepoSignals | None:
@@ -416,7 +553,10 @@ class Renderer:
                 "paths": topic.paths,
                 "next": topic.next,
             }
-        return {
+        result = {
             "generated_at": self.fixed_timestamp,
             "topics": topics,
         }
+        if self.config.source_catalog_summary_path:
+            result["source_inventory"] = self._build_source_inventory_dict()
+        return result

--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -47,6 +47,42 @@ class SourceObservatorySignals:
 
 
 @dataclass
+class SourceCatalogSource:
+    """Compact inventory summary for a single source from source-observatory."""
+
+    source_id: str
+    protocol: str
+    items: int | None
+    titled: int | None
+    inventory_method: str
+    api_base_url: str
+    status: str
+
+
+@dataclass
+class IntakeCandidate:
+    """Compact intake candidate summary from source-observatory."""
+
+    source_id: str
+    item_name: str
+    title: str
+    granularity: str
+    year_min: int | None
+    year_max: int | None
+    intake_score: int | float | None
+
+
+@dataclass
+class SourceCatalogSummary:
+    """Aggregated source inventory summary from source-observatory."""
+
+    captured_at: str
+    sources: list[SourceCatalogSource] = field(default_factory=list)
+    intake_candidates: list[IntakeCandidate] = field(default_factory=list)
+    summary: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
 class RepoSignal:
     """Single signal entry following the repo-signals standard v1."""
 
@@ -145,4 +181,59 @@ def parse_source_observatory_signals(raw: str) -> SourceObservatorySignals:
         captured_at=data.get("captured_at", "unknown"),
         sources_checked=data.get("sources_checked", len(signals)),
         signals=signals,
+    )
+
+
+def parse_source_catalog_summary(raw: str) -> SourceCatalogSummary:
+    """Parse a lightweight source catalog summary JSON string.
+
+    Args:
+        raw: Raw JSON content of a source catalog summary file
+
+    Returns:
+        Parsed SourceCatalogSummary instance
+
+    Raises:
+        ValueError: If the JSON is invalid
+    """
+    try:
+        data: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON: {exc}") from exc
+
+    sources = [
+        SourceCatalogSource(
+            source_id=s.get("source_id", s.get("source", "")),
+            protocol=s.get("protocol", ""),
+            items=s.get("items", s.get("rows")),
+            titled=s.get("titled", s.get("items_with_title")),
+            inventory_method=s.get("inventory_method", s.get("method", "")),
+            api_base_url=s.get("api_base_url", ""),
+            status=s.get("status", ""),
+        )
+        for s in data.get("sources", [])
+    ]
+
+    intake_candidates = [
+        IntakeCandidate(
+            source_id=c.get("source_id", c.get("source", "")),
+            item_name=c.get("item_name", c.get("item", "")),
+            title=c.get("title", ""),
+            granularity=c.get("granularity", ""),
+            year_min=c.get("year_min"),
+            year_max=c.get("year_max"),
+            intake_score=c.get("intake_score"),
+        )
+        for c in data.get("intake_candidates", [])
+    ]
+
+    summary = data.get("summary", {})
+    if not isinstance(summary, dict):
+        summary = {}
+
+    return SourceCatalogSummary(
+        captured_at=data.get("captured_at", "unknown"),
+        sources=sources,
+        intake_candidates=intake_candidates,
+        summary=summary,
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,6 +31,7 @@ def test_config_without_workspace_root():
     """workspace_root is optional — GitHub-only mode."""
     config = Config(github_org="test-org", repos=["repo1"])
     assert config.workspace_root is None
+    assert config.source_catalog_summary_path is None
 
 
 def test_load_config_yaml_without_workspace_root(tmp_path):
@@ -72,6 +73,25 @@ topics:
     assert config.repos == ["repo1", "repo2"]
     assert "test-topic" in config.topics
     assert config.topics["test-topic"].repos == ["repo1"]
+
+
+def test_load_config_yaml_source_catalog_summary_path(tmp_path):
+    """YAML config can opt in to a source-observatory inventory artifact."""
+    config_file = tmp_path / "test.yml"
+    config_file.write_text(
+        """
+github_org: test-org
+repos:
+  - repo1
+source_catalog_summary_path: data/catalog_inventory/generated/source_catalog_summary.json
+"""
+    )
+
+    config = load_config(config_file)
+    assert (
+        config.source_catalog_summary_path
+        == "data/catalog_inventory/generated/source_catalog_summary.json"
+    )
 
 
 def test_load_config_missing_file():

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -291,6 +291,44 @@ def _sample_di_json() -> str:
     })
 
 
+def _sample_source_catalog_summary_json() -> str:
+    return json.dumps({
+        "captured_at": "2026-04-17T10:00:00",
+        "summary": {"sources": 2, "candidates": 1},
+        "sources": [
+            {
+                "source_id": "inps",
+                "protocol": "ckan",
+                "items": 2323,
+                "titled": 500,
+                "inventory_method": "package_list",
+                "api_base_url": "https://dati.inps.it/api/3/action",
+                "status": "ok",
+            },
+            {
+                "source_id": "mur_ustat",
+                "protocol": "sdmx",
+                "items": 83,
+                "titled": 83,
+                "inventory_method": "dataflow_count",
+                "api_base_url": "https://dati.ustat.miur.it/SDMXWS/rest",
+                "status": "ok",
+            },
+        ],
+        "intake_candidates": [
+            {
+                "source_id": "mur_ustat",
+                "item_name": "iscrizioni",
+                "title": "Iscrizioni universitarie",
+                "granularity": "nazionale",
+                "year_min": 2011,
+                "year_max": 2011,
+                "intake_score": 47,
+            }
+        ],
+    })
+
+
 def test_render_signals_cached_across_bootstrap_and_triage():
     """Each remote file is fetched exactly once across bootstrap + triage.
 
@@ -302,7 +340,6 @@ def test_render_signals_cached_across_bootstrap_and_triage():
 
     so_json = _sample_so_json(regression=False)
     di_json = _sample_di_json()
-
     def _raw_file_side_effect(repo, path, ref="main"):
         if path == "data/catalog/catalog_signals.json":
             return so_json
@@ -316,7 +353,7 @@ def test_render_signals_cached_across_bootstrap_and_triage():
     renderer.render_session_bootstrap()
     renderer.render_workspace_triage()
 
-    # Two distinct files (SO catalog_signals + DI pipeline_signals), each fetched once
+    # Two enabled summaries (SO catalog_signals + DI pipeline_signals), each fetched once.
     assert gh.get_raw_file.call_count == 2
     paths_fetched = [call.args[1] for call in gh.get_raw_file.call_args_list]
     assert "data/catalog/catalog_signals.json" in paths_fetched
@@ -341,3 +378,77 @@ def test_render_topic_index():
 
     assert "topics" in topics
     assert "topic1" in topics["topics"]
+
+
+def test_render_bootstrap_source_inventory_section():
+    """Bootstrap includes compact Source Inventory summary when available."""
+    config = Config(
+        workspace_root=None,
+        github_org="test-org",
+        repos=["repo1"],
+        source_catalog_summary_path="data/catalog_inventory/generated/source_catalog_summary.json",
+    )
+    gh = _make_github_mock()
+
+    source_catalog_json = _sample_source_catalog_summary_json()
+
+    def _raw_file_side_effect(repo, path, ref="main"):
+        if path == "data/catalog_inventory/generated/source_catalog_summary.json":
+            return source_catalog_json
+        return None
+
+    gh.get_raw_file.side_effect = _raw_file_side_effect
+    renderer = Renderer(config, gh, _make_git_mock())
+
+    bootstrap = renderer.render_session_bootstrap()
+    triage = renderer.render_workspace_triage()
+
+    assert "Source Inventory" in bootstrap
+    assert "inps" in bootstrap
+    assert "mur_ustat" in bootstrap
+    assert triage["source_inventory"]["available"] is True
+    assert triage["source_inventory"]["sources"][0]["source_id"] == "inps"
+    assert triage["source_inventory"]["intake_candidates"][0]["intake_score"] == 47
+    assert "data/catalog_inventory/generated/source_catalog_summary.json" in [
+        call.args[1] for call in gh.get_raw_file.call_args_list
+    ]
+
+
+def test_render_source_inventory_disabled_by_default():
+    """Source Inventory is not rendered unless an artifact path is configured."""
+    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
+    renderer = Renderer(config, _make_github_mock(), _make_git_mock())
+
+    bootstrap = renderer.render_session_bootstrap()
+    triage = renderer.render_workspace_triage()
+    topic_index = renderer.render_topic_index()
+
+    assert "Source Inventory" not in bootstrap
+    assert "source_inventory" not in triage
+    assert "source_inventory" not in topic_index
+
+
+def test_render_topic_index_includes_source_inventory():
+    """Topic index carries the source inventory summary for downstream consumers."""
+    config = Config(
+        workspace_root=None,
+        github_org="test-org",
+        repos=["repo1"],
+        source_catalog_summary_path="data/catalog_inventory/generated/source_catalog_summary.json",
+    )
+    gh = _make_github_mock()
+
+    source_catalog_json = _sample_source_catalog_summary_json()
+
+    def _raw_file_side_effect(repo, path, ref="main"):
+        if path == "data/catalog_inventory/generated/source_catalog_summary.json":
+            return source_catalog_json
+        return None
+
+    gh.get_raw_file.side_effect = _raw_file_side_effect
+    renderer = Renderer(config, gh, _make_git_mock())
+
+    topic_index = renderer.render_topic_index()
+
+    assert topic_index["source_inventory"]["available"] is True
+    assert topic_index["source_inventory"]["captured_at"] == "2026-04-17T10:00:00"

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -5,9 +5,11 @@ import pytest
 
 from agent_context_builder.signals import (
     RepoSignals,
+    SourceCatalogSummary,
     SourceObservatorySignals,
     SourceSignal,
     parse_repo_signals,
+    parse_source_catalog_summary,
     parse_source_observatory_signals,
 )
 
@@ -168,3 +170,18 @@ def test_parse_repo_signals_missing_fields_use_defaults():
     assert rs.generated_at == "unknown"
     assert rs.signals[0].status == "ok"
     assert rs.signals[0].label == "test"
+
+
+def test_parse_source_catalog_summary_uses_defaults():
+    raw = json.dumps({
+        "captured_at": "2026-04-17",
+        "sources": [{"source_id": "inps"}],
+        "intake_candidates": [{"source_id": "mur_ustat", "title": "Test"}],
+    })
+    summary = parse_source_catalog_summary(raw)
+    assert isinstance(summary, SourceCatalogSummary)
+    assert summary.captured_at == "2026-04-17"
+    assert summary.sources[0].source_id == "inps"
+    assert summary.sources[0].protocol == ""
+    assert summary.intake_candidates[0].item_name == ""
+    assert summary.intake_candidates[0].title == "Test"


### PR DESCRIPTION
## Summary
- add parser/dataclasses for Source Observatory source_catalog_summary artifacts
- fetch and cache the SO source inventory from current and recent artifact paths
- surface Source Inventory in session_bootstrap, workspace_triage, and topic_index
- cover parser, cache, bootstrap, triage, and topic_index behavior in tests

Closes #18.

## Tests
- pytest -q tests/test_signals.py tests/test_render.py
- pytest -q