### PR TITLE
Consuma il clean catalog di dataset-incubator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ da GitHub e, se disponibile, dai checkout locali dei repo Lab.
 
 La CI aggiorna gli artifact GitHub-only ogni 6 ore sul branch `context`.
 
+## Artifact Consumati
+
+ACB preferisce artifact JSON generati e versionati dai repo Lab rispetto a
+frontmatter o README manuali. Oggi consuma:
+
+| Repo | Path | Uso |
+|---|---|---|
+| `source-observatory` | `data/catalog/catalog_signals.json` | health e regressioni sorgenti |
+| `dataset-incubator` | `registry/pipeline_signals.json` | stato operativo candidate |
+| `dataset-incubator` | `registry/clean_catalog.json` | dataset clean/queryable disponibili |
+
 URL raw:
 
 ```text

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -8,9 +8,11 @@ from .discussions import Discussion, DiscussionCollector
 from .github import GitHubCollector, PR
 from .git_local import GitLocalCollector, GitState
 from .signals import (
+    DICleanCatalog,
     RadarSummary,
     RepoSignals,
     SourceObservatorySignals,
+    parse_di_clean_catalog,
     parse_radar_summary,
     parse_repo_signals,
     parse_source_observatory_signals,
@@ -50,6 +52,7 @@ class Renderer:
         self._so_signals_cache: SourceObservatorySignals | None | type[_UNSET] = _UNSET
         self._radar_cache: RadarSummary | None | type[_UNSET] = _UNSET
         self._di_signals_cache: RepoSignals | None | type[_UNSET] = _UNSET
+        self._di_clean_catalog_cache: DICleanCatalog | None | type[_UNSET] = _UNSET
 
     def render_session_bootstrap(self) -> str:
         """Render session_bootstrap.md.
@@ -147,6 +150,10 @@ class Renderer:
         # Pipeline state (only warn/error candidates)
         di = self._fetch_di_pipeline_signals()
         lines += self._render_pipeline_state_section(di)
+
+        # Dataset catalog (clean/queryable datasets)
+        catalog = self._fetch_di_clean_catalog()
+        lines += self._render_dataset_catalog_section(catalog)
 
         return "\n".join(lines)
 
@@ -308,6 +315,7 @@ class Renderer:
             "radar": self._build_radar_dict(),
             "source_health": self._build_source_health_dict(),
             "pipeline_state": self._build_pipeline_state_dict(),
+            "dataset_catalog": self._build_dataset_catalog_dict(),
         }
         return triage
 
@@ -381,6 +389,23 @@ class Renderer:
         self._di_signals_cache = result
         return result
 
+    def _fetch_di_clean_catalog(self) -> DICleanCatalog | None:
+        if self._di_clean_catalog_cache is not _UNSET:
+            return self._di_clean_catalog_cache  # type: ignore[return-value]
+        raw = self.github_collector.get_raw_file(
+            "dataset-incubator", "registry/clean_catalog.json"
+        )
+        if raw is None:
+            self._di_clean_catalog_cache = None
+            return None
+        try:
+            result = parse_di_clean_catalog(raw)
+        except ValueError as exc:
+            self.github_collector.fetch_errors["dataset-incubator:clean_catalog"] = str(exc)
+            result = None
+        self._di_clean_catalog_cache = result
+        return result
+
     def _render_pipeline_state_section(self, di: RepoSignals | None) -> list[str]:
         lines = []
         lines.append("## Pipeline State")
@@ -416,6 +441,96 @@ class Renderer:
         )
         lines.append("")
         return lines
+
+    def _render_dataset_catalog_section(
+        self, catalog: DICleanCatalog | None
+    ) -> list[str]:
+        lines = []
+        lines.append("## Dataset Catalog")
+        lines.append("")
+        if catalog is None:
+            err = self.github_collector.fetch_errors.get(
+                "dataset-incubator:clean_catalog"
+            ) or self.github_collector.fetch_errors.get(
+                "dataset-incubator:registry/clean_catalog.json"
+            )
+            if err:
+                lines.append(f"> *clean_catalog unavailable — {err}*")
+            else:
+                lines.append("> *clean_catalog unavailable*")
+            lines.append("")
+            return lines
+
+        clean_ready = catalog.clean_ready
+        public_count = sum(1 for d in clean_ready if d.visibility == "public")
+        lines.append(
+            f"*{len(clean_ready)} clean_ready dataset(s), "
+            f"{public_count} public* (updated {catalog.updated_at})"
+        )
+        for dataset in clean_ready[:8]:
+            period = self._format_period(dataset.period)
+            location = dataset.location.get("path", "")
+            line = f"- **{dataset.slug}** ({dataset.status}, {dataset.visibility}): "
+            line += dataset.name
+            if period:
+                line += f" [{period}]"
+            line += (
+                f" - {dataset.metric_columns} metric, "
+                f"{dataset.dimension_columns} dimension columns"
+            )
+            if location:
+                line += f" - `{location}`"
+            lines.append(line)
+        if len(clean_ready) > 8:
+            lines.append(f"- *...and {len(clean_ready) - 8} more clean_ready datasets*")
+        lines.append("")
+        return lines
+
+    def _build_dataset_catalog_dict(self) -> dict[str, Any]:
+        catalog = self._fetch_di_clean_catalog()
+        if catalog is None:
+            return {
+                "available": False,
+                "errors": {
+                    k: v for k, v in self.github_collector.fetch_errors.items()
+                    if "clean_catalog" in k
+                },
+            }
+        return {
+            "available": True,
+            "schema_version": catalog.schema_version,
+            "name": catalog.name,
+            "updated_at": catalog.updated_at,
+            "summary": {
+                "total": len(catalog.datasets),
+                "clean_ready": len(catalog.clean_ready),
+                "public": sum(1 for d in catalog.clean_ready if d.visibility == "public"),
+            },
+            "datasets": [
+                {
+                    "slug": d.slug,
+                    "name": d.name,
+                    "status": d.status,
+                    "visibility": d.visibility,
+                    "period": d.period,
+                    "location": d.location,
+                    "metric_columns": d.metric_columns,
+                    "dimension_columns": d.dimension_columns,
+                    "column_count": d.column_count,
+                }
+                for d in catalog.datasets
+            ],
+        }
+
+    @staticmethod
+    def _format_period(period: dict[str, Any]) -> str:
+        start = period.get("start")
+        end = period.get("end")
+        if start is None and end is None:
+            return ""
+        if start == end:
+            return str(start)
+        return f"{start or '?'}-{end or '?'}"
 
     def _build_pipeline_state_dict(self) -> dict[str, Any]:
         di = self._fetch_di_pipeline_signals()

--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -74,6 +74,36 @@ class RepoSignals:
         return [s for s in self.signals if s.status in ("warn", "error")]
 
 
+@dataclass
+class DICleanDataset:
+    """Single clean dataset entry from dataset-incubator clean_catalog.json."""
+
+    slug: str
+    name: str
+    status: str
+    visibility: str
+    period: dict[str, Any] = field(default_factory=dict)
+    location: dict[str, Any] = field(default_factory=dict)
+    metric_columns: int = 0
+    dimension_columns: int = 0
+    column_count: int = 0
+
+
+@dataclass
+class DICleanCatalog:
+    """Clean dataset catalog from dataset-incubator registry."""
+
+    schema_version: str
+    name: str
+    updated_at: str
+    datasets: list[DICleanDataset] = field(default_factory=list)
+
+    @property
+    def clean_ready(self) -> list[DICleanDataset]:
+        """Datasets with status clean_ready."""
+        return [d for d in self.datasets if d.status == "clean_ready"]
+
+
 def parse_repo_signals(raw: str) -> RepoSignals:
     """Parse a repo-signals standard v1 JSON string.
 
@@ -109,6 +139,54 @@ def parse_repo_signals(raw: str) -> RepoSignals:
         topic=data.get("topic", ""),
         signals=signals,
         summary=data.get("summary", {}),
+    )
+
+
+def parse_di_clean_catalog(raw: str) -> DICleanCatalog:
+    """Parse dataset-incubator registry/clean_catalog.json.
+
+    ACB keeps the fields needed for agent orientation and triage. Descriptive
+    metadata such as description, source, and registry_source remains in the
+    upstream catalog and is intentionally omitted from this compact model.
+
+    Args:
+        raw: Raw JSON content of clean_catalog.json
+
+    Returns:
+        Parsed DICleanCatalog instance
+
+    Raises:
+        ValueError: If the JSON is invalid
+    """
+    try:
+        data: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON: {exc}") from exc
+
+    datasets = []
+    for item in data.get("datasets", []):
+        columns = item.get("columns", [])
+        metric_columns = sum(1 for c in columns if c.get("role") == "metric")
+        dimension_columns = sum(1 for c in columns if c.get("role") == "dimension")
+        datasets.append(
+            DICleanDataset(
+                slug=item.get("slug", ""),
+                name=item.get("name", item.get("slug", "")),
+                status=item.get("status", ""),
+                visibility=item.get("visibility", ""),
+                period=item.get("period", {}),
+                location=item.get("location", {}),
+                metric_columns=metric_columns,
+                dimension_columns=dimension_columns,
+                column_count=len(columns),
+            )
+        )
+
+    return DICleanCatalog(
+        schema_version=str(data.get("schema_version", "1")),
+        name=data.get("name", ""),
+        updated_at=data.get("updated_at", "unknown"),
+        datasets=datasets,
     )
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -330,6 +330,39 @@ def _sample_di_json() -> str:
     })
 
 
+def _sample_di_clean_catalog_json() -> str:
+    return json.dumps({
+        "schema_version": 1,
+        "name": "Lab Clean Registry",
+        "updated_at": "2026-04-14",
+        "datasets": [
+            {
+                "slug": "irpef_comunale",
+                "name": "IRPEF Comunale",
+                "status": "clean_ready",
+                "visibility": "public",
+                "period": {"start": 2022, "end": 2023},
+                "location": {
+                    "type": "gcs",
+                    "path": "gs://dataciviclab-clean/irpef/irpef.parquet",
+                },
+                "columns": [
+                    {"name": "anno", "role": "dimension"},
+                    {"name": "comune", "role": "dimension"},
+                    {"name": "imposta", "role": "metric"},
+                ],
+            },
+            {
+                "slug": "draft_dataset",
+                "name": "Draft Dataset",
+                "status": "draft",
+                "visibility": "private",
+                "columns": [],
+            },
+        ],
+    })
+
+
 def test_render_signals_cached_across_bootstrap_and_triage():
     """Each remote file is fetched exactly once across bootstrap + triage.
 
@@ -341,12 +374,15 @@ def test_render_signals_cached_across_bootstrap_and_triage():
 
     so_json = _sample_so_json(regression=False)
     di_json = _sample_di_json()
+    clean_catalog_json = _sample_di_clean_catalog_json()
 
     def _raw_file_side_effect(repo, path, ref="main"):
         if path == "data/catalog/catalog_signals.json":
             return so_json
         if path == "registry/pipeline_signals.json":
             return di_json
+        if path == "registry/clean_catalog.json":
+            return clean_catalog_json
         return None
 
     gh.get_raw_file.side_effect = _raw_file_side_effect
@@ -355,12 +391,14 @@ def test_render_signals_cached_across_bootstrap_and_triage():
     renderer.render_session_bootstrap()
     renderer.render_workspace_triage()
 
-    # Three distinct files (radar_summary + catalog_signals + DI pipeline_signals), each fetched once
-    assert gh.get_raw_file.call_count == 3
+    # Four distinct files (radar_summary + catalog_signals + DI pipeline_signals + DI clean catalog), each fetched once
+    assert gh.get_raw_file.call_count == 4
     paths_fetched = [call.args[1] for call in gh.get_raw_file.call_args_list]
+    assert "data/radar/radar_summary.json" in paths_fetched
     assert "data/radar/radar_summary.json" in paths_fetched
     assert "data/catalog/catalog_signals.json" in paths_fetched
     assert "registry/pipeline_signals.json" in paths_fetched
+    assert "registry/clean_catalog.json" in paths_fetched
 
 
 def test_render_topic_index():
@@ -381,3 +419,58 @@ def test_render_topic_index():
 
     assert "topics" in topics
     assert "topic1" in topics["topics"]
+
+
+def test_render_bootstrap_dataset_catalog_section():
+    """Bootstrap includes clean dataset catalog summary when available."""
+    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
+    gh = _make_github_mock()
+
+    def _raw_file_side_effect(repo, path, ref="main"):
+        if path == "registry/clean_catalog.json":
+            return _sample_di_clean_catalog_json()
+        return None
+
+    gh.get_raw_file.side_effect = _raw_file_side_effect
+    renderer = Renderer(config, gh, _make_git_mock())
+
+    bootstrap = renderer.render_session_bootstrap()
+
+    assert "Dataset Catalog" in bootstrap
+    assert "1 clean_ready dataset(s), 1 public" in bootstrap
+    assert "irpef_comunale" in bootstrap
+    assert "1 metric, 2 dimension columns" in bootstrap
+    assert "draft_dataset" not in bootstrap
+
+
+def test_render_triage_dataset_catalog_available():
+    """Triage includes machine-readable clean catalog entries."""
+    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
+    gh = _make_github_mock()
+
+    def _raw_file_side_effect(repo, path, ref="main"):
+        if path == "registry/clean_catalog.json":
+            return _sample_di_clean_catalog_json()
+        return None
+
+    gh.get_raw_file.side_effect = _raw_file_side_effect
+    renderer = Renderer(config, gh, _make_git_mock())
+
+    catalog = renderer.render_workspace_triage()["dataset_catalog"]
+
+    assert catalog["available"] is True
+    assert catalog["updated_at"] == "2026-04-14"
+    assert catalog["summary"] == {"total": 2, "clean_ready": 1, "public": 1}
+    assert catalog["datasets"][0]["slug"] == "irpef_comunale"
+    assert catalog["datasets"][0]["metric_columns"] == 1
+    assert catalog["datasets"][0]["dimension_columns"] == 2
+
+
+def test_render_triage_dataset_catalog_unavailable():
+    """Triage marks dataset catalog unavailable when clean_catalog fetch fails."""
+    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
+    renderer = Renderer(config, _make_github_mock(raw_file=None), _make_git_mock())
+
+    catalog = renderer.render_workspace_triage()["dataset_catalog"]
+
+    assert catalog["available"] is False

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -4,9 +4,11 @@ import json
 import pytest
 
 from agent_context_builder.signals import (
+    DICleanCatalog,
     RepoSignals,
     SourceObservatorySignals,
     SourceSignal,
+    parse_di_clean_catalog,
     parse_repo_signals,
     parse_source_observatory_signals,
 )
@@ -197,3 +199,50 @@ def test_parse_radar_summary():
     assert summary.red == 0
     assert len(summary.unhealthy) == 1
     assert summary.unhealthy[0].id == "anac"
+
+
+def test_parse_di_clean_catalog_basic():
+    raw = json.dumps({
+        "schema_version": 1,
+        "name": "Lab Clean Registry",
+        "updated_at": "2026-04-14",
+        "datasets": [
+            {
+                "slug": "irpef_comunale",
+                "name": "IRPEF Comunale",
+                "status": "clean_ready",
+                "visibility": "public",
+                "period": {"start": 2022, "end": 2023},
+                "location": {"type": "gcs", "path": "gs://bucket/irpef.parquet"},
+                "columns": [
+                    {"name": "anno", "role": "dimension"},
+                    {"name": "comune", "role": "dimension"},
+                    {"name": "imposta", "role": "metric"},
+                ],
+            }
+        ],
+    })
+
+    catalog = parse_di_clean_catalog(raw)
+
+    assert isinstance(catalog, DICleanCatalog)
+    assert catalog.schema_version == "1"
+    assert catalog.updated_at == "2026-04-14"
+    assert len(catalog.clean_ready) == 1
+    dataset = catalog.datasets[0]
+    assert dataset.slug == "irpef_comunale"
+    assert dataset.metric_columns == 1
+    assert dataset.dimension_columns == 2
+    assert dataset.column_count == 3
+
+
+def test_parse_di_clean_catalog_missing_fields_use_defaults():
+    raw = json.dumps({"datasets": [{"slug": "minimal"}]})
+
+    catalog = parse_di_clean_catalog(raw)
+
+    assert catalog.name == ""
+    assert catalog.updated_at == "unknown"
+    assert catalog.datasets[0].name == "minimal"
+    assert catalog.datasets[0].status == ""
+    assert catalog.datasets[0].location == {}


### PR DESCRIPTION
## Sintesi
- aggiunge parser e modelli per `dataset-incubator/registry/clean_catalog.json`
- legge e mette in cache `registry/clean_catalog.json` insieme a `pipeline_signals.json`
- aggiunge la sezione `Dataset Catalog` in `session_bootstrap.md`
- aggiunge il campo `dataset_catalog` in `workspace_triage.json`
- documenta nel README gli artifact JSON upstream consumati, così README/frontmatter non diventano source of truth

Closes #17.

## Verifica
- `pytest -q`