### PR TITLE
feat: consuma radar_summary.json da source-observatory

### DIFF
--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -8,8 +8,10 @@ from .discussions import Discussion, DiscussionCollector
 from .github import GitHubCollector, PR
 from .git_local import GitLocalCollector, GitState
 from .signals import (
+    RadarSummary,
     RepoSignals,
     SourceObservatorySignals,
+    parse_radar_summary,
     parse_repo_signals,
     parse_source_observatory_signals,
 )
@@ -46,6 +48,7 @@ class Renderer:
         self.fixed_timestamp = fixed_timestamp or datetime.now().isoformat()
         # Cache for remote signal fetches — avoids double requests within one build
         self._so_signals_cache: SourceObservatorySignals | None | type[_UNSET] = _UNSET
+        self._radar_cache: RadarSummary | None | type[_UNSET] = _UNSET
         self._di_signals_cache: RepoSignals | None | type[_UNSET] = _UNSET
 
     def render_session_bootstrap(self) -> str:
@@ -133,6 +136,10 @@ class Renderer:
                 lines.append(f"- {topic_name}")
             lines.append("")
 
+        # Radar health (GREEN/YELLOW/RED per fonte)
+        radar = self._fetch_radar_summary()
+        lines += self._render_radar_section(radar)
+
         # Source health (only issues — skip stable sources)
         so = self._fetch_source_observatory_signals()
         lines += self._render_source_health_section(so)
@@ -142,6 +149,41 @@ class Renderer:
         lines += self._render_pipeline_state_section(di)
 
         return "\n".join(lines)
+
+    def _fetch_radar_summary(self) -> RadarSummary | None:
+        if self._radar_cache is not _UNSET:
+            return self._radar_cache  # type: ignore[return-value]
+        raw = self.github_collector.get_raw_file(
+            "source-observatory", "data/radar/radar_summary.json"
+        )
+        if raw is None:
+            self._radar_cache = None
+            return None
+        try:
+            result = parse_radar_summary(raw)
+        except ValueError as exc:
+            self.github_collector.fetch_errors["source-observatory:radar_summary"] = str(exc)
+            result = None
+        self._radar_cache = result
+        return result
+
+    def _render_radar_section(self, radar: RadarSummary | None) -> list[str]:
+        lines = ["## Radar Status", ""]
+        if radar is None:
+            lines.append("> *radar_summary unavailable*")
+            lines.append("")
+            return lines
+        lines.append(
+            f"Fonti: {radar.sources_total} — "
+            f"GREEN {radar.green} · YELLOW {radar.yellow} · RED {radar.red} "
+            f"(probe: {radar.probe_date})"
+        )
+        if radar.unhealthy:
+            lines.append("")
+            for s in radar.unhealthy:
+                lines.append(f"- **{s.id}** ({s.protocol}): {s.status} [HTTP {s.http_code}]")
+        lines.append("")
+        return lines
 
     def _fetch_source_observatory_signals(self) -> SourceObservatorySignals | None:
         if self._so_signals_cache is not _UNSET:
@@ -263,10 +305,28 @@ class Renderer:
                 for repo, state in repos_state.items()
             },
             "warnings": self._collect_warnings(prs, repos_state),
+            "radar": self._build_radar_dict(),
             "source_health": self._build_source_health_dict(),
             "pipeline_state": self._build_pipeline_state_dict(),
         }
         return triage
+
+    def _build_radar_dict(self) -> dict[str, Any]:
+        radar = self._fetch_radar_summary()
+        if radar is None:
+            return {"available": False}
+        return {
+            "available": True,
+            "probe_date": radar.probe_date,
+            "sources_total": radar.sources_total,
+            "green": radar.green,
+            "yellow": radar.yellow,
+            "red": radar.red,
+            "unhealthy": [
+                {"id": s.id, "status": s.status, "protocol": s.protocol, "http_code": s.http_code}
+                for s in radar.unhealthy
+            ],
+        }
 
     def _build_source_health_dict(self) -> dict[str, Any]:
         so = self._fetch_source_observatory_signals()

--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -146,3 +146,64 @@ def parse_source_observatory_signals(raw: str) -> SourceObservatorySignals:
         sources_checked=data.get("sources_checked", len(signals)),
         signals=signals,
     )
+
+
+@dataclass
+class RadarSource:
+    """Single source entry from radar_summary.json."""
+
+    id: str
+    status: str
+    protocol: str
+    observation_mode: str
+    http_code: str
+    last_check: str
+    datasets_in_use: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RadarSummary:
+    """Radar health summary from source-observatory radar_summary.json."""
+
+    generated_at: str
+    probe_date: str
+    sources_total: int
+    green: int
+    yellow: int
+    red: int
+    sources: list[RadarSource] = field(default_factory=list)
+
+    @property
+    def unhealthy(self) -> list[RadarSource]:
+        return [s for s in self.sources if s.status in ("YELLOW", "RED")]
+
+
+def parse_radar_summary(raw: str) -> RadarSummary:
+    try:
+        data: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON: {exc}") from exc
+
+    counts = data.get("status_counts", {})
+    sources = [
+        RadarSource(
+            id=s.get("id", ""),
+            status=s.get("status", ""),
+            protocol=s.get("protocol", ""),
+            observation_mode=s.get("observation_mode", ""),
+            http_code=s.get("http_code", "-"),
+            last_check=s.get("last_check", ""),
+            datasets_in_use=s.get("datasets_in_use") or [],
+        )
+        for s in data.get("sources", [])
+    ]
+
+    return RadarSummary(
+        generated_at=data.get("generated_at", "unknown"),
+        probe_date=data.get("probe_date", "unknown"),
+        sources_total=data.get("sources_total", len(sources)),
+        green=counts.get("GREEN", 0),
+        yellow=counts.get("YELLOW", 0),
+        red=counts.get("RED", 0),
+        sources=sources,
+    )

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -355,9 +355,10 @@ def test_render_signals_cached_across_bootstrap_and_triage():
     renderer.render_session_bootstrap()
     renderer.render_workspace_triage()
 
-    # Two distinct files (SO catalog_signals + DI pipeline_signals), each fetched once
-    assert gh.get_raw_file.call_count == 2
+    # Three distinct files (radar_summary + catalog_signals + DI pipeline_signals), each fetched once
+    assert gh.get_raw_file.call_count == 3
     paths_fetched = [call.args[1] for call in gh.get_raw_file.call_args_list]
+    assert "data/radar/radar_summary.json" in paths_fetched
     assert "data/catalog/catalog_signals.json" in paths_fetched
     assert "registry/pipeline_signals.json" in paths_fetched
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -168,3 +168,32 @@ def test_parse_repo_signals_missing_fields_use_defaults():
     assert rs.generated_at == "unknown"
     assert rs.signals[0].status == "ok"
     assert rs.signals[0].label == "test"
+
+
+def test_parse_radar_summary():
+    from agent_context_builder.signals import parse_radar_summary
+
+    raw = json.dumps({
+        "generated_at": "2026-04-19T09:00:00+00:00",
+        "probe_date": "2026-04-19",
+        "sources_total": 3,
+        "status_counts": {"GREEN": 2, "YELLOW": 1, "RED": 0},
+        "sources": [
+            {"id": "inps", "status": "GREEN", "protocol": "ckan",
+             "observation_mode": "catalog-watch", "http_code": "200",
+             "last_check": "2026-04-19", "datasets_in_use": ["ds1"]},
+            {"id": "anac", "status": "YELLOW", "protocol": "ckan",
+             "observation_mode": "radar-only", "http_code": "200",
+             "last_check": "2026-04-19", "datasets_in_use": []},
+            {"id": "istat", "status": "GREEN", "protocol": "sdmx",
+             "observation_mode": "catalog-watch", "http_code": "200",
+             "last_check": "2026-04-19", "datasets_in_use": []},
+        ],
+    })
+    summary = parse_radar_summary(raw)
+    assert summary.sources_total == 3
+    assert summary.green == 2
+    assert summary.yellow == 1
+    assert summary.red == 0
+    assert len(summary.unhealthy) == 1
+    assert summary.unhealthy[0].id == "anac"


### PR DESCRIPTION
## Summary

- Aggiunge `RadarSource`, `RadarSummary`, `parse_radar_summary()` in `signals.py`
- `render.py`: nuova sezione `## Radar Status` in `session_bootstrap` con conteggi GREEN/YELLOW/RED e lista fonti unhealthy; `radar` dict in `workspace_triage`
- Cache separata `_radar_cache` per evitare doppi fetch
- Test: `test_parse_radar_summary` in `test_signals.py`, aggiornato `call_count` in `test_render.py` (2 → 3 fetch distinti)

Dipende da source-observatory#118 (già mergiata su main).
Sostituisce #19 (chiusa — puntava a `source_catalog_summary.json` non prodotto da nessuno).

## Test plan

- [x] 49 test passati localmente
- [x] Run locale `agent-context build` — sezione Radar Status presente in `session_bootstrap.md`
- [ ] Verificare sezione Radar Status popolata dopo merge (SO #118 già su main, radar_summary.json committato)

🤖 Generated with [Claude Code](https://claude.com/claude-code)