### PR TITLE
feat: consuma discovered_portals_summary.json (portal scout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ frontmatter o README manuali. Oggi consuma:
 
 | Repo | Path | Uso |
 |---|---|---|
-| `source-observatory` | `data/catalog/catalog_signals.json` | health e regressioni sorgenti |
-| `dataset-incubator` | `registry/pipeline_signals.json` | stato operativo candidate |
+| `source-observatory` | `data/radar/radar_summary.json` | health complessivo delle fonti nel registry |
+| `source-observatory` | `data/catalog/catalog_signals.json` | segnali di regressione per singola fonte |
+| `source-observatory` | `data/portal_scout/discovered_portals_summary.json` | nuovi portali PA scoperti da portal-scout |
+| `dataset-incubator` | `registry/pipeline_signals.json` | stato operativo dei dataset candidate |
 | `dataset-incubator` | `registry/clean_catalog.json` | dataset clean/queryable disponibili |
 
 URL raw:

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -275,7 +275,7 @@ class Renderer:
         issues = so.regressions + so.alerts
         if issues:
             for s in issues:
-                lines.append(f"- **{s.source}** ({s.protocol}): {s.result} — {s.detail}")
+                lines.append(f"- **{s.source}** ({s.protocol}): {s.result}")
                 if s.suggested_action and s.suggested_action != "nessuna":
                     lines.append(f"  - azione: {s.suggested_action}")
         else:
@@ -513,17 +513,9 @@ class Renderer:
         )
         for dataset in clean_ready[:8]:
             period = self._format_period(dataset.period)
-            location = dataset.location.get("path", "")
-            line = f"- **{dataset.slug}** ({dataset.status}, {dataset.visibility}): "
-            line += dataset.name
+            line = f"- **{dataset.slug}** ({dataset.visibility}): {dataset.name}"
             if period:
                 line += f" [{period}]"
-            line += (
-                f" - {dataset.metric_columns} metric, "
-                f"{dataset.dimension_columns} dimension columns"
-            )
-            if location:
-                line += f" - `{location}`"
             lines.append(line)
         if len(clean_ready) > 8:
             lines.append(f"- *...and {len(clean_ready) - 8} more clean_ready datasets*")

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -9,10 +9,12 @@ from .github import GitHubCollector, PR
 from .git_local import GitLocalCollector, GitState
 from .signals import (
     DICleanCatalog,
+    PortalScoutSummary,
     RadarSummary,
     RepoSignals,
     SourceObservatorySignals,
     parse_di_clean_catalog,
+    parse_portal_scout_summary,
     parse_radar_summary,
     parse_repo_signals,
     parse_source_observatory_signals,
@@ -51,6 +53,7 @@ class Renderer:
         # Cache for remote signal fetches — avoids double requests within one build
         self._so_signals_cache: SourceObservatorySignals | None | type[_UNSET] = _UNSET
         self._radar_cache: RadarSummary | None | type[_UNSET] = _UNSET
+        self._portal_scout_cache: PortalScoutSummary | None | type[_UNSET] = _UNSET
         self._di_signals_cache: RepoSignals | None | type[_UNSET] = _UNSET
         self._di_clean_catalog_cache: DICleanCatalog | None | type[_UNSET] = _UNSET
 
@@ -155,6 +158,10 @@ class Renderer:
         catalog = self._fetch_di_clean_catalog()
         lines += self._render_dataset_catalog_section(catalog)
 
+        # Portal scout (nuovi candidati strutturati)
+        scout = self._fetch_portal_scout()
+        lines += self._render_portal_scout_section(scout)
+
         return "\n".join(lines)
 
     def _fetch_radar_summary(self) -> RadarSummary | None:
@@ -189,6 +196,42 @@ class Renderer:
             lines.append("")
             for s in radar.unhealthy:
                 lines.append(f"- **{s.id}** ({s.protocol}): {s.status} [HTTP {s.http_code}]")
+        lines.append("")
+        return lines
+
+    def _fetch_portal_scout(self) -> PortalScoutSummary | None:
+        if self._portal_scout_cache is not _UNSET:
+            return self._portal_scout_cache  # type: ignore[return-value]
+        raw = self.github_collector.get_raw_file(
+            "source-observatory", "data/portal_scout/discovered_portals_summary.json"
+        )
+        if raw is None:
+            self._portal_scout_cache = None
+            return None
+        try:
+            result = parse_portal_scout_summary(raw)
+        except ValueError as exc:
+            self.github_collector.fetch_errors["source-observatory:portal_scout"] = str(exc)
+            result = None
+        self._portal_scout_cache = result
+        return result
+
+    def _render_portal_scout_section(self, scout: PortalScoutSummary | None) -> list[str]:
+        lines = ["## Portal Scout", ""]
+        if scout is None:
+            lines.append("> *discovered_portals_summary unavailable*")
+            lines.append("")
+            return lines
+        lines.append(
+            f"Portali rilevati: {scout.total_portals} — "
+            f"nuovi candidati: {scout.new_candidates} — "
+            f"strutturati confermati: {scout.new_confirmed_protocol}"
+        )
+        if scout.new_structured:
+            lines.append("")
+            lines.append("**Nuovi candidati strutturati:**")
+            for c in scout.new_structured:
+                lines.append(f"- `{c.domain}` — {c.protocol.upper()}")
         lines.append("")
         return lines
 
@@ -316,6 +359,7 @@ class Renderer:
             "source_health": self._build_source_health_dict(),
             "pipeline_state": self._build_pipeline_state_dict(),
             "dataset_catalog": self._build_dataset_catalog_dict(),
+            "portal_scout": self._build_portal_scout_dict(),
         }
         return triage
 
@@ -531,6 +575,23 @@ class Renderer:
         if start == end:
             return str(start)
         return f"{start or '?'}-{end or '?'}"
+
+    def _build_portal_scout_dict(self) -> dict[str, Any]:
+        scout = self._fetch_portal_scout()
+        if scout is None:
+            return {"available": False}
+        return {
+            "available": True,
+            "generated_at": scout.generated_at,
+            "total_portals": scout.total_portals,
+            "new_candidates": scout.new_candidates,
+            "new_confirmed_protocol": scout.new_confirmed_protocol,
+            "by_protocol": scout.by_protocol,
+            "new_structured": [
+                {"domain": c.domain, "protocol": c.protocol}
+                for c in scout.new_structured
+            ],
+        }
 
     def _build_pipeline_state_dict(self) -> dict[str, Any]:
         di = self._fetch_di_pipeline_signals()

--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -285,3 +285,54 @@ def parse_radar_summary(raw: str) -> RadarSummary:
         red=counts.get("RED", 0),
         sources=sources,
     )
+
+
+@dataclass
+class PortalCandidate:
+    """Single portal candidate from discovered_portals_summary.json."""
+
+    domain: str
+    protocol: str
+    probe_url: str
+
+
+@dataclass
+class PortalScoutSummary:
+    """Portal discovery summary from source-observatory discovered_portals_summary.json."""
+
+    generated_at: str
+    total_portals: int
+    new_candidates: int
+    new_confirmed_protocol: int
+    known_registry_seen: int
+    by_protocol: dict[str, int]
+    new_structured: list[PortalCandidate] = field(default_factory=list)
+    known_registry_healthcheck: list[PortalCandidate] = field(default_factory=list)
+
+
+def parse_portal_scout_summary(raw: str) -> PortalScoutSummary:
+    try:
+        data: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON: {exc}") from exc
+
+    def _parse_candidates(items: list[dict[str, Any]]) -> list[PortalCandidate]:
+        return [
+            PortalCandidate(
+                domain=c.get("domain", ""),
+                protocol=c.get("protocol", ""),
+                probe_url=c.get("probe_url", ""),
+            )
+            for c in items
+        ]
+
+    return PortalScoutSummary(
+        generated_at=data.get("generated_at", "unknown"),
+        total_portals=data.get("total_portals", 0),
+        new_candidates=data.get("new_candidates", 0),
+        new_confirmed_protocol=data.get("new_confirmed_protocol", 0),
+        known_registry_seen=data.get("known_registry_seen", 0),
+        by_protocol=data.get("by_protocol", {}),
+        new_structured=_parse_candidates(data.get("new_structured", [])),
+        known_registry_healthcheck=_parse_candidates(data.get("known_registry_healthcheck", [])),
+    )

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -391,14 +391,14 @@ def test_render_signals_cached_across_bootstrap_and_triage():
     renderer.render_session_bootstrap()
     renderer.render_workspace_triage()
 
-    # Four distinct files (radar_summary + catalog_signals + DI pipeline_signals + DI clean catalog), each fetched once
-    assert gh.get_raw_file.call_count == 4
+    # Five distinct files fetched once each
+    assert gh.get_raw_file.call_count == 5
     paths_fetched = [call.args[1] for call in gh.get_raw_file.call_args_list]
-    assert "data/radar/radar_summary.json" in paths_fetched
     assert "data/radar/radar_summary.json" in paths_fetched
     assert "data/catalog/catalog_signals.json" in paths_fetched
     assert "registry/pipeline_signals.json" in paths_fetched
     assert "registry/clean_catalog.json" in paths_fetched
+    assert "data/portal_scout/discovered_portals_summary.json" in paths_fetched
 
 
 def test_render_topic_index():


### PR DESCRIPTION
## Summary

- Aggiunge `PortalCandidate`, `PortalScoutSummary`, `parse_portal_scout_summary` in `signals.py`
- `render.py` fetcha `data/portal_scout/discovered_portals_summary.json` da SO e mostra i nuovi candidati strutturati in `session_bootstrap` e `workspace_triage`
- Usa il nuovo schema (`new_structured` / `known_registry_healthcheck`) — allineato con SO #119

## Dipendenza

Richiede merge di SO #119 per avere il file su main di source-observatory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)