### PR TITLE
ci: aggiungi job test con pytest e codecov

### DIFF
--- a/.github/workflows/build-context.yml
+++ b/.github/workflows/build-context.yml
@@ -10,9 +10,38 @@ on:
     paths:
       - 'dataciviclab.config.yml'
       - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install
+        run: pip install -e ".[dev]"
+
+      - name: Test
+        run: pytest --cov=src/agent_context_builder --cov-report=xml
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: false
+
   build:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/build-context.yml
+++ b/.github/workflows/build-context.yml
@@ -13,6 +13,7 @@ on:
       - 'tests/**'
       - 'pyproject.toml'
   pull_request:
+    branches: [main]
     paths:
       - 'src/**'
       - 'tests/**'
@@ -42,6 +43,7 @@ jobs:
 
   build:
     needs: test
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Sintesi

Aggiunge un job `test` alla CI che gira pytest con coverage reporting, e rende il job `build` dipendente dal superamento dei test.

## Cosa cambia

- **trigger `pull_request`**: nuovo, oltre al già esistente `push` su main
- **path filter allargato**: `tests/**` e `pyproject.toml` inclusi oltre a `src/**`
- **job `test`**: `pytest --cov` su ubuntu-latest python 3.12, upload coverage su codecov
- **job `build`**: `needs: test` — non gira se i test falliscono

Cron e workflow_dispatch continuano a funzionare indipendentemente.

## Verifica

- [x] `pytest -q` verde in locale (56 passed)
- [ ] CI verde su questo branch

## Schema

```
jobs:
  test:     ← gira su PR e push
    needs:  []
    runs:   ubuntu-latest
    steps:  checkout → python 3.12 → pip install -e ".[dev]" → pytest --cov → codecov

  build:    ← gira solo dopo test passati
    needs:  [test]
    runs:   ubuntu-latest
    steps:  checkout → python 3.12 → pip install -e . → agent-context build → publish to context branch
```