### PR TITLE
fix(mcp): graceful error handling nei tool read-only

### DIFF
--- a/src/agent_context_builder/mcp_server.py
+++ b/src/agent_context_builder/mcp_server.py
@@ -125,19 +125,28 @@ def _fetch(path: str) -> str:
 @mcp.tool()
 def session_bootstrap() -> str:
     """Orientamento rapido: repo attivi, PR aperte, discussion, stato locale, topic."""
-    return _fetch("session_bootstrap.md")
+    try:
+        return _fetch("session_bootstrap.md")
+    except requests.HTTPError as e:
+        return f"session_bootstrap: {e}"
 
 
 @mcp.tool()
 def workspace_triage() -> str:
     """Triage machine-readable: PR, issue, discussion, stato git per repo, warning."""
-    return _fetch("workspace_triage.json")
+    try:
+        return _fetch("workspace_triage.json")
+    except requests.HTTPError as e:
+        return f"workspace_triage: {e}"
 
 
 @mcp.tool()
 def topic_index() -> str:
     """Topic index v2 — repos, datasets_by_source, operational_topics."""
-    return _fetch("topic_index.json")
+    try:
+        return _fetch("topic_index.json")
+    except requests.HTTPError as e:
+        return f"topic_index: {e}"
 
 
 @mcp.tool()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,5 +1,6 @@
 """Tests for MCP server resources and tools."""
 
+import requests
 from unittest.mock import MagicMock, patch
 
 
@@ -143,3 +144,47 @@ def test_refresh_context_api_error(monkeypatch):
         result = refresh_context()
 
     assert "403" in result
+
+
+def _mock_http_error(status: int):
+    """Return a mock raising HTTPError."""
+    response = _mock_response("error", status=status)
+    exc = requests.HTTPError(f"{status} Client Error", response=response)
+    response.raise_for_status.side_effect = exc
+    return response
+
+
+def test_session_bootstrap_http_error(monkeypatch):
+    """session_bootstrap returns error string on HTTP failure instead of raising."""
+    from agent_context_builder.mcp_server import session_bootstrap
+
+    with patch("agent_context_builder.mcp_server.requests.get") as mock_get:
+        mock_get.return_value = _mock_http_error(403)
+        result = session_bootstrap()
+
+    assert "session_bootstrap" in result
+    assert "403" in result
+
+
+def test_workspace_triage_http_error(monkeypatch):
+    """workspace_triage returns error string on HTTP failure instead of raising."""
+    from agent_context_builder.mcp_server import workspace_triage
+
+    with patch("agent_context_builder.mcp_server.requests.get") as mock_get:
+        mock_get.return_value = _mock_http_error(404)
+        result = workspace_triage()
+
+    assert "workspace_triage" in result
+    assert "404" in result
+
+
+def test_topic_index_http_error(monkeypatch):
+    """topic_index returns error string on HTTP failure instead of raising."""
+    from agent_context_builder.mcp_server import topic_index
+
+    with patch("agent_context_builder.mcp_server.requests.get") as mock_get:
+        mock_get.return_value = _mock_http_error(500)
+        result = topic_index()
+
+    assert "topic_index" in result
+    assert "500" in result


### PR DESCRIPTION
## Sintesi

I tre tool MCP read-only (`session_bootstrap`, `workspace_triage`, `topic_index`) ora catturano `requests.HTTPError` e restituiscono una stringa di errore contestuale invece di crashare.

## Problema

`_fetch` usa `raise_for_status()` — quando GitHub è down, rate-limited, o il branch/context non esiste, l'MCP tool sollevava un'eccezione non gestita, mandando in crash il server o restituendo un internal error al client.

## Soluzione

Wrap in `try/except requests.HTTPError` in ogni tool, con messaggio che include il nome del tool e il codice HTTP:

```
session_bootstrap: 403 Client Error
workspace_triage: 404 Not Found
topic_index: 500 Server Error
```

`refresh_context` era già protetto (gestisce esplicitamente il codice 204).

## Test

3 nuovi test:
- `test_session_bootstrap_http_error` — 403
- `test_workspace_triage_http_error` — 404
- `test_topic_index_http_error` — 500

57 test passano, coverage `mcp_server.py` 97%.

## Verifica

- [x] `pytest -q` verde (57 passed)
- [x] CI verde