### PR TITLE
feat: surface pending signals from upstream artifacts + MCP improvements

### DIFF
--- a/src/agent_context_builder/mcp_server.py
+++ b/src/agent_context_builder/mcp_server.py
@@ -9,12 +9,17 @@ One optional tool:
   refresh_context — triggers a new CI build (requires GITHUB_TOKEN with workflow scope)
 
 Configuration via environment variables:
-  ACB_REPO    GitHub repo (default: dataciviclab/agent-context-builder)
-  ACB_BRANCH  Branch where artifacts are published (default: context)
-  GITHUB_TOKEN  Required only for the refresh_context tool
+  ACB_REPO       GitHub repo (default: dataciviclab/agent-context-builder)
+  ACB_BRANCH     Branch where artifacts are published (default: context)
+  GITHUB_TOKEN   Required only for the refresh_context tool
+  ACB_LOG_LEVEL  Logging level, default INFO (options: DEBUG, INFO, WARNING, ERROR)
 """
 
+import json
+import logging
 import os
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import requests
@@ -24,6 +29,26 @@ _REPO = os.environ.get("ACB_REPO", "dataciviclab/agent-context-builder")
 _BRANCH = os.environ.get("ACB_BRANCH", "context")
 _RAW_BASE = f"https://raw.githubusercontent.com/{_REPO}/{_BRANCH}"
 _API_BASE = f"https://api.github.com/repos/{_REPO}"
+
+# Rate-limit guard: GitHub allows ~2 workflow dispatches per hour per repo/ref
+_REFRESH_MIN_INTERVAL = 60  # seconds — local guard before hitting GitHub limit
+_last_refresh_attempt: float | None = None
+
+_log = logging.getLogger(__name__)
+
+
+def _configure_logging() -> None:
+    """Configure structured logging from ACB_LOG_LEVEL env var."""
+    level_name = os.environ.get("ACB_LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format='{"ts":"%(asctime)s","level":"%(levelname)s","name":"%(name)s","msg":"%(message)s"}',
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+
+
+_configure_logging()
 
 mcp = FastMCP(
     "dataciviclab-context",
@@ -113,13 +138,58 @@ def _get_env(name: str) -> str | None:
     return os.environ.get(name)
 
 
-def _fetch(path: str) -> str:
-    """Fetch a file from the context branch."""
+def _tool_error(tool: str, path: str, message: str, status_code: int | None = None) -> str:
+    """Return a structured JSON error string for tool failures."""
+    return json.dumps({
+        "ok": False,
+        "tool": tool,
+        "path": path,
+        "error": message,
+        "status_code": status_code,
+        "ts": datetime.now(timezone.utc).isoformat(),
+    })
+
+
+def _fetch(path: str, retries: int = 1, backoff: float = 1.0) -> str:
+    """Fetch a file from the context branch with optional retry on transient errors.
+
+    Args:
+        path: Path on the context branch (e.g. "session_bootstrap.md")
+        retries: Number of retries on 5xx or network errors (default 1, meaning one attempt + up to 1 retry)
+        backoff: Initial backoff seconds, doubled on each retry (default 1.0)
+    """
     token = _get_env("GITHUB_TOKEN")
     headers = {"Authorization": f"token {token}"} if token else {}
-    response = requests.get(f"{_RAW_BASE}/{path}", headers=headers, timeout=10)
-    response.raise_for_status()
-    return response.text
+    url = f"{_RAW_BASE}/{path}"
+    attempt = 0
+    last_err: Exception | None = None
+
+    while attempt <= retries:
+        try:
+            response = requests.get(url, headers=headers, timeout=10)
+            response.raise_for_status()
+            _log.info("fetch_success path=%s status=%d", path, response.status_code)
+            return response.text
+        except requests.HTTPError as e:
+            # Don't retry on 4xx — they won't become valid by retrying
+            if e.response is not None and 400 <= e.response.status_code < 500:
+                _log.warning("fetch_client_error path=%s status=%d", path, e.response.status_code)
+                raise
+            last_err = e
+        except requests.RequestException as e:
+            last_err = e
+
+        attempt += 1
+        if attempt <= retries:
+            sleep = backoff * (2 ** (attempt - 1))
+            _log.warning("fetch_retry path=%s attempt=%d sleep=%.1f error=%s", path, attempt, sleep, last_err)
+            time.sleep(sleep)
+        else:
+            _log.error("fetch_failed path=%s error=%s", path, last_err)
+            raise last_err
+
+    # Should never reach here, but mypy needs it
+    raise RuntimeError("unreachable")
 
 
 @mcp.tool()
@@ -127,8 +197,11 @@ def session_bootstrap() -> str:
     """Orientamento rapido: repo attivi, PR aperte, discussion, stato locale, topic."""
     try:
         return _fetch("session_bootstrap.md")
-    except requests.HTTPError as e:
-        return f"session_bootstrap: {e}"
+    except Exception as e:
+        return _tool_error(
+            "session_bootstrap", "session_bootstrap.md", str(e),
+            e.response.status_code if isinstance(e, requests.HTTPError) and e.response else None
+        )
 
 
 @mcp.tool()
@@ -136,8 +209,11 @@ def workspace_triage() -> str:
     """Triage machine-readable: PR, issue, discussion, stato git per repo, warning."""
     try:
         return _fetch("workspace_triage.json")
-    except requests.HTTPError as e:
-        return f"workspace_triage: {e}"
+    except Exception as e:
+        return _tool_error(
+            "workspace_triage", "workspace_triage.json", str(e),
+            e.response.status_code if isinstance(e, requests.HTTPError) and e.response else None
+        )
 
 
 @mcp.tool()
@@ -145,8 +221,11 @@ def topic_index() -> str:
     """Topic index v2 — repos, datasets_by_source, operational_topics."""
     try:
         return _fetch("topic_index.json")
-    except requests.HTTPError as e:
-        return f"topic_index: {e}"
+    except Exception as e:
+        return _tool_error(
+            "topic_index", "topic_index.json", str(e),
+            e.response.status_code if isinstance(e, requests.HTTPError) and e.response else None
+        )
 
 
 @mcp.tool()
@@ -155,30 +234,86 @@ def refresh_context() -> str:
 
     Richiede GITHUB_TOKEN con scope workflow.
     Gli artifact aggiornati saranno disponibili entro ~1 minuto.
+
+    Rate-limit: GitHub allows ~2 dispatches per hour per repo/ref.
+    This tool enforces a local guard of one dispatch per minute.
     """
+    global _last_refresh_attempt
+
     token = _get_env("GITHUB_TOKEN")
     if not token:
-        return (
-            "Errore: GITHUB_TOKEN non impostato. "
-            "Serve un token con scope 'workflow' per triggerare il build."
-        )
+        return json.dumps({
+            "ok": False,
+            "tool": "refresh_context",
+            "error": "GITHUB_TOKEN non impostato. Serve un token con scope 'workflow'.",
+            "ts": datetime.now(timezone.utc).isoformat(),
+        })
 
-    response = requests.post(
-        f"{_API_BASE}/actions/workflows/build-context.yml/dispatches",
-        json={"ref": "main"},
-        headers={
-            "Authorization": f"token {token}",
-            "Accept": "application/vnd.github+json",
-        },
-        timeout=10,
-    )
-    if response.status_code == 204:
-        return "Build triggerato. Gli artifact saranno aggiornati entro ~1 minuto."
-    return f"Errore: {response.status_code} — {response.text}"
+    now = time.monotonic()
+    if _last_refresh_attempt is not None:
+        elapsed = now - _last_refresh_attempt
+        if elapsed < _REFRESH_MIN_INTERVAL:
+            wait = _REFRESH_MIN_INTERVAL - elapsed
+            return json.dumps({
+                "ok": False,
+                "tool": "refresh_context",
+                "error": f"Troppo presto. Ultimo tentativo {int(elapsed)}s fa. "
+                         f"Aspetta ~{int(wait)}s prima di riprovare.",
+                "retry_after": int(wait),
+                "ts": datetime.now(timezone.utc).isoformat(),
+            })
+
+    _last_refresh_attempt = now
+    try:
+        response = requests.post(
+            f"{_API_BASE}/actions/workflows/build-context.yml/dispatches",
+            json={"ref": "main"},
+            headers={
+                "Authorization": f"token {token}",
+                "Accept": "application/vnd.github+json",
+            },
+            timeout=10,
+        )
+        if response.status_code == 204:
+            _log.info("refresh_triggered ref=main")
+            return json.dumps({
+                "ok": True,
+                "tool": "refresh_context",
+                "message": "Build triggerato. Artifact aggiornati entro ~1 minuto.",
+                "ts": datetime.now(timezone.utc).isoformat(),
+            })
+        elif response.status_code == 422:
+            # 422 = workflow disabled or ref not allowed — don't retry
+            _log.error("refresh_rejected status=%d body=%s", response.status_code, response.text)
+            return json.dumps({
+                "ok": False,
+                "tool": "refresh_context",
+                "error": "Build rifiutato (422). Verifica che il workflow sia abilitato su main.",
+                "status_code": 422,
+                "ts": datetime.now(timezone.utc).isoformat(),
+            })
+        else:
+            _log.error("refresh_failed status=%d body=%s", response.status_code, response.text)
+            return json.dumps({
+                "ok": False,
+                "tool": "refresh_context",
+                "error": f"Errore {response.status_code}: {response.text}",
+                "status_code": response.status_code,
+                "ts": datetime.now(timezone.utc).isoformat(),
+            })
+    except requests.RequestException as e:
+        _log.error("refresh_network_error error=%s", e)
+        return json.dumps({
+            "ok": False,
+            "tool": "refresh_context",
+            "error": f"Errore di rete: {e}",
+            "ts": datetime.now(timezone.utc).isoformat(),
+        })
 
 
 def main() -> None:
     """Entry point per l'MCP server."""
+    _log.info("starting mcp server repo=%s branch=%s", _REPO, _BRANCH)
     mcp.run()
 
 

--- a/src/agent_context_builder/mcp_server.py
+++ b/src/agent_context_builder/mcp_server.py
@@ -38,7 +38,14 @@ _log = logging.getLogger(__name__)
 
 
 def _configure_logging() -> None:
-    """Configure structured logging from ACB_LOG_LEVEL env var."""
+    """Configure structured JSON logging from ACB_LOG_LEVEL env var.
+
+    Only calls basicConfig if the root logger has no handlers configured.
+    This avoids overriding logging setup from pytest --log-level or other
+    environments that pre-configure the root logger.
+    """
+    if logging.root.handlers:
+        return  # already configured — don't override
     level_name = os.environ.get("ACB_LOG_LEVEL", "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
     logging.basicConfig(

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -216,8 +216,6 @@ class Renderer:
         lines.append("")
         return "\n".join(lines)
 
-        return "\n".join(lines)
-
     def _fetch_radar_summary(self) -> RadarSummary | None:
         return self._so_fetcher.fetch_radar_summary()
 

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -177,7 +177,12 @@ class Renderer:
         if radar.unhealthy:
             lines.append("")
             for s in radar.unhealthy:
-                lines.append(f"- **{s.id}** ({s.protocol}): {s.status} [HTTP {s.http_code}]")
+                datasets_info = ""
+                if s.datasets_in_use:
+                    datasets_info = " — ↳ " + ", ".join(s.datasets_in_use)
+                lines.append(
+                    f"- **{s.id}** ({s.protocol}): {s.status} [HTTP {s.http_code}]{datasets_info}"
+                )
         lines.append("")
         return lines
 
@@ -340,6 +345,16 @@ class Renderer:
             + ", ".join(f"{v} {k}" for k, v in sorted(by_status.items()) if v)
             + ")*"
         )
+        # Surface failed sample runs inline with the run URL
+        failed_runs = di.failed_runs
+        if failed_runs:
+            lines.append("")
+            for s in failed_runs:
+                run = s.sample_run
+                lines.append(
+                    f"- ⚠️ **{s.label}** — run fallito "
+                    f"[{run.year}]({run.run_url})"
+                )
         lines.append("")
         return lines
 
@@ -410,6 +425,10 @@ class Renderer:
                     "metric_columns": d.metric_columns,
                     "dimension_columns": d.dimension_columns,
                     "column_count": d.column_count,
+                    "columns": [
+                        {"name": c.name, "role": c.role}
+                        for c in d.columns
+                    ] if d.status == "clean_ready" else [],
                 }
                 for d in catalog.datasets
             ],
@@ -511,10 +530,19 @@ class Renderer:
         # Datasets grouped by source from clean_catalog
         catalog = self._fetch_di_clean_catalog()
         datasets_by_source: dict[str, list[dict[str, Any]]] = {}
+        candidates_by_source: dict[str, list[dict[str, Any]]] = {}
         if catalog:
             for ds in catalog.clean_ready:
                 source = ds.source or "unknown"
                 datasets_by_source.setdefault(source, []).append({
+                    "slug": ds.slug,
+                    "name": ds.name,
+                    "period": ds.period,
+                    "visibility": ds.visibility,
+                })
+            for ds in catalog.candidates:
+                source = ds.source or "unknown"
+                candidates_by_source.setdefault(source, []).append({
                     "slug": ds.slug,
                     "name": ds.name,
                     "period": ds.period,
@@ -537,5 +565,6 @@ class Renderer:
             "generated_at": self.fixed_timestamp,
             "repos": repos_section,
             "datasets_by_source": datasets_by_source,
+            "candidates_by_source": candidates_by_source,
             "operational_topics": operational_topics,
         }

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -221,88 +221,14 @@ class Renderer:
     def _fetch_radar_summary(self) -> RadarSummary | None:
         return self._so_fetcher.fetch_radar_summary()
 
-    def _render_radar_section(self, radar: RadarSummary | None) -> list[str]:
-        lines = ["## Radar Status", ""]
-        if radar is None:
-            lines.append("> *radar_summary unavailable*")
-            lines.append("")
-            return lines
-        lines.append(
-            f"Fonti: {radar.sources_total} — "
-            f"GREEN {radar.green} · YELLOW {radar.yellow} · RED {radar.red} "
-            f"(probe: {radar.probe_date})"
-        )
-        if radar.unhealthy:
-            lines.append("")
-            for s in radar.unhealthy:
-                datasets_info = ""
-                if s.datasets_in_use:
-                    datasets_info = " — ↳ " + ", ".join(s.datasets_in_use)
-                lines.append(
-                    f"- **{s.id}** ({s.protocol}): {s.status} [HTTP {s.http_code}]{datasets_info}"
-                )
-        lines.append("")
-        return lines
 
     def _fetch_portal_scout(self) -> PortalScoutSummary | None:
         return self._so_fetcher.fetch_portal_scout()
 
-    def _render_portal_scout_section(self, scout: PortalScoutSummary | None) -> list[str]:
-        lines = ["## Portal Scout", ""]
-        if scout is None:
-            lines.append("> *discovered_portals_summary unavailable*")
-            lines.append("")
-            return lines
-        lines.append(
-            f"Portali rilevati: {scout.total_portals} — "
-            f"nuovi candidati: {scout.new_candidates} — "
-            f"strutturati confermati: {scout.new_confirmed_protocol}"
-        )
-        if scout.new_structured:
-            lines.append("")
-            lines.append("**Nuovi candidati strutturati:**")
-            for c in scout.new_structured:
-                lines.append(f"- `{c.domain}` — {c.protocol.upper()}")
-        lines.append("")
-        return lines
 
     def _fetch_source_observatory_signals(self) -> SourceObservatorySignals | None:
         return self._so_fetcher.fetch_catalog_signals()
 
-    def _render_source_health_section(
-        self, so: SourceObservatorySignals | None
-    ) -> list[str]:
-        lines = []
-        lines.append("## Catalog Drift")
-        lines.append("")
-        if so is None:
-            err = self.github_collector.fetch_errors.get(
-                "source-observatory:data/catalog/catalog_signals.json"
-            ) or self.github_collector.fetch_errors.get(
-                "source-observatory:catalog_signals"
-            )
-            if err:
-                lines.append(f"> *catalog_signals unavailable — {err}*")
-            else:
-                lines.append("> *catalog_signals unavailable*")
-            lines.append("")
-            return lines
-
-        issues = so.drift_alerts
-        if issues:
-            for s in issues:
-                lines.append(f"- **{s.source}** ({s.protocol}): {s.signal_type}")
-                if s.suggested_action and s.suggested_action != "nessuna":
-                    lines.append(f"  - azione: {s.suggested_action}")
-        else:
-            lines.append(
-                f"*No catalog drift signals* "
-                f"(as of {so.captured_at}, {so.sources_checked} sources checked)"
-            )
-        if issues:
-            lines.append(f"  *(captured {so.captured_at}, {so.sources_checked} sources checked)*")
-        lines.append("")
-        return lines
 
     def render_workspace_triage(self) -> dict[str, Any]:
         """Render workspace_triage.json.
@@ -320,49 +246,7 @@ class Renderer:
             di_fetcher=self._di_fetcher,
         )
 
-    def _build_radar_dict(self) -> dict[str, Any]:
-        radar = self._so_fetcher.fetch_radar_summary()
-        if radar is None:
-            return {"available": False}
-        return {
-            "available": True,
-            "probe_date": radar.probe_date,
-            "sources_total": radar.sources_total,
-            "green": radar.green,
-            "yellow": radar.yellow,
-            "red": radar.red,
-            "unhealthy": [
-                {"id": s.id, "status": s.status, "protocol": s.protocol, "http_code": s.http_code}
-                for s in radar.unhealthy
-            ],
-        }
 
-    def _build_source_health_dict(self) -> dict[str, Any]:
-        so = self._so_fetcher.fetch_catalog_signals()
-        if so is None:
-            return {
-                "available": False,
-                "errors": {
-                    k: v for k, v in self.github_collector.fetch_errors.items()
-                    if "source-observatory" in k
-                },
-            }
-        return {
-            "available": True,
-            "captured_at": so.captured_at,
-            "sources_checked": so.sources_checked,
-            "alerts": [
-                {
-                    "source": s.source,
-                    "protocol": s.protocol,
-                    "signal_type": s.signal_type,
-                    "result": s.result,
-                    "detail": s.detail,
-                    "suggested_action": s.suggested_action,
-                }
-                for s in so.drift_alerts
-            ],
-        }
 
     def _fetch_di_pipeline_signals(self) -> RepoSignals | None:
         return self._di_fetcher.fetch_pipeline_signals()
@@ -370,127 +254,8 @@ class Renderer:
     def _fetch_di_clean_catalog(self) -> DICleanCatalog | None:
         return self._di_fetcher.fetch_clean_catalog()
 
-    def _render_pipeline_state_section(self, di: RepoSignals | None) -> list[str]:
-        lines = []
-        lines.append("## Pipeline State")
-        lines.append("")
-        if di is None:
-            err = self.github_collector.fetch_errors.get(
-                "dataset-incubator:registry/pipeline_signals.json"
-            ) or self.github_collector.fetch_errors.get(
-                "dataset-incubator:pipeline_signals"
-            )
-            if err:
-                lines.append(f"> *pipeline_signals unavailable — {err}*")
-            else:
-                lines.append("> *pipeline_signals unavailable*")
-            lines.append("")
-            return lines
 
-        summary = di.summary
-        total = summary.get("total", len(di.signals))
-        by_status = summary.get("by_status", {})
-        actionable = di.actionable
-        if actionable:
-            for s in actionable:
-                lines.append(f"- **{s.label}** [{s.status}]: {s.detail}")
-                if s.action:
-                    lines.append(f"  - azione: {s.action}")
-        else:
-            lines.append(f"*{total} candidates, tutti ok*")
-        lines.append(
-            f"  *(as of {di.generated_at} — "
-            + ", ".join(f"{v} {k}" for k, v in sorted(by_status.items()) if v)
-            + ")*"
-        )
-        # Surface failed sample runs inline with the run URL
-        failed_runs = di.failed_runs
-        if failed_runs:
-            lines.append("")
-            for s in failed_runs:
-                run = s.sample_run
-                lines.append(
-                    f"- ⚠️ **{s.label}** — run fallito "
-                    f"[{run.year}]({run.run_url})"
-                )
-        lines.append("")
-        return lines
 
-    def _render_dataset_catalog_section(
-        self, catalog: DICleanCatalog | None
-    ) -> list[str]:
-        lines = []
-        lines.append("## Dataset Catalog")
-        lines.append("")
-        if catalog is None:
-            err = self.github_collector.fetch_errors.get(
-                "dataset-incubator:clean_catalog"
-            ) or self.github_collector.fetch_errors.get(
-                "dataset-incubator:registry/clean_catalog.json"
-            )
-            if err:
-                lines.append(f"> *clean_catalog unavailable — {err}*")
-            else:
-                lines.append("> *clean_catalog unavailable*")
-            lines.append("")
-            return lines
-
-        clean_ready = catalog.clean_ready
-        public_count = sum(1 for d in clean_ready if d.visibility == "public")
-        lines.append(
-            f"*{len(clean_ready)} clean_ready dataset(s), "
-            f"{public_count} public* (updated {catalog.updated_at})"
-        )
-        for dataset in clean_ready[:8]:
-            period = self._format_period(dataset.period)
-            line = f"- **{dataset.slug}** ({dataset.visibility}): {dataset.name}"
-            if period:
-                line += f" [{period}]"
-            lines.append(line)
-        if len(clean_ready) > 8:
-            lines.append(f"- *...and {len(clean_ready) - 8} more clean_ready datasets*")
-        lines.append("")
-        return lines
-
-    def _build_dataset_catalog_dict(self) -> dict[str, Any]:
-        catalog = self._di_fetcher.fetch_clean_catalog()
-        if catalog is None:
-            return {
-                "available": False,
-                "errors": {
-                    k: v for k, v in self.github_collector.fetch_errors.items()
-                    if "clean_catalog" in k
-                },
-            }
-        return {
-            "available": True,
-            "schema_version": catalog.schema_version,
-            "name": catalog.name,
-            "updated_at": catalog.updated_at,
-            "summary": {
-                "total": len(catalog.datasets),
-                "clean_ready": len(catalog.clean_ready),
-                "public": sum(1 for d in catalog.clean_ready if d.visibility == "public"),
-            },
-            "datasets": [
-                {
-                    "slug": d.slug,
-                    "name": d.name,
-                    "status": d.status,
-                    "visibility": d.visibility,
-                    "period": d.period,
-                    "location": d.location,
-                    "metric_columns": d.metric_columns,
-                    "dimension_columns": d.dimension_columns,
-                    "column_count": d.column_count,
-                    "columns": [
-                        {"name": c.name, "role": c.role}
-                        for c in d.columns
-                    ] if d.status == "clean_ready" else [],
-                }
-                for d in catalog.datasets
-            ],
-        }
 
     @staticmethod
     def _format_period(period: dict[str, Any]) -> str:
@@ -502,42 +267,7 @@ class Renderer:
             return str(start)
         return f"{start or '?'}-{end or '?'}"
 
-    def _build_portal_scout_dict(self) -> dict[str, Any]:
-        scout = self._so_fetcher.fetch_portal_scout()
-        if scout is None:
-            return {"available": False}
-        return {
-            "available": True,
-            "generated_at": scout.generated_at,
-            "total_portals": scout.total_portals,
-            "new_candidates": scout.new_candidates,
-            "new_confirmed_protocol": scout.new_confirmed_protocol,
-            "by_protocol": scout.by_protocol,
-            "new_structured": [
-                {"domain": c.domain, "protocol": c.protocol}
-                for c in scout.new_structured
-            ],
-        }
 
-    def _build_pipeline_state_dict(self) -> dict[str, Any]:
-        di = self._fetch_di_pipeline_signals()
-        if di is None:
-            return {
-                "available": False,
-                "errors": {
-                    k: v for k, v in self.github_collector.fetch_errors.items()
-                    if "dataset-incubator" in k
-                },
-            }
-        return {
-            "available": True,
-            "generated_at": di.generated_at,
-            "summary": di.summary,
-            "actionable": [
-                {"id": s.id, "status": s.status, "detail": s.detail, "action": s.action}
-                for s in di.actionable
-            ],
-        }
 
     def _collect_warnings(
         self, prs: list[PR], repos_state: dict[str, GitState]

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -51,8 +51,8 @@ class Renderer:
     def render_session_bootstrap(self) -> str:
         """Render session_bootstrap.md.
 
-        Returns:
-            Markdown content (target: 80-120 lines)
+        Organized by Lab phase: SCOUTING → INTAKE → OPEN → INFRA.
+        Target: ~40 lines. Details live in workspace_triage.json.
         """
         lines = []
         lines.append("# Session Bootstrap")
@@ -62,101 +62,159 @@ class Renderer:
             lines.append(f"**Workspace**: {self.config.workspace_root}")
         lines.append("")
 
-        # Active repos with GitHub description
-        lines.append("## Repos")
-        lines.append("")
-        repos_info = self.github_collector.get_repos_info(self.config.repos)
-        for repo in self.config.repos:
-            info = repos_info.get(repo)
-            if info and info.description:
-                lines.append(f"- **{repo}**: {info.description}")
+        # ── SCOUTING ────────────────────────────────────────────────────
+        radar = self._fetch_radar_summary()
+        so = self._fetch_source_observatory_signals()
+        scout = self._fetch_portal_scout()
+        has_scouting = radar is not None or so is not None or scout is not None
+
+        if has_scouting:
+            lines.append("## 🔍 SCOUTING")
+            lines.append("")
+
+            # Radar
+            if radar is not None:
+                lines.append(
+                    f"**Radar**: {radar.sources_total} fonti — "
+                    f"GREEN {radar.green} · YELLOW {radar.yellow} · RED {radar.red} "
+                    f"(probe: {radar.probe_date})"
+                )
+                if radar.unhealthy:
+                    for s in radar.unhealthy:
+                        di = f" — ↳ {', '.join(s.datasets_in_use)}" if s.datasets_in_use else ""
+                        lines.append(
+                            f"  · **{s.id}** {s.status} [{s.http_code}]{di}"
+                        )
             else:
-                lines.append(f"- {repo}")
+                lines.append("**Radar**: unavailable")
+
+            # Catalog drift
+            if so is None:
+                lines.append("**Catalog Drift**: unavailable")
+            else:
+                issues = so.drift_alerts
+                if issues:
+                    for s in issues:
+                        action = f" — azione: {s.suggested_action}" if s.suggested_action not in ("nessuna", "") else ""
+                        lines.append(f"  · **{s.source}** ({s.protocol}): {s.signal_type}{action}")
+                else:
+                    lines.append(
+                        f"**Catalog Drift**: no drift signals "
+                        f"({so.sources_checked} sources checked)"
+                    )
+
+            # Portal scout
+            if scout is not None:
+                lines.append(
+                    f"**Portal Scout**: {scout.total_portals} portali · "
+                    f"{scout.new_candidates} nuovi candidati · "
+                    f"{scout.new_confirmed_protocol} strutturati"
+                )
+                if scout.new_structured:
+                    domains = [c.domain for c in scout.new_structured[:3]]
+                    extra = f" + {len(scout.new_structured) - 3} altri" if len(scout.new_structured) > 3 else ""
+                    lines.append(f"  · **Nuovi CKAN**: {', '.join(domains)}{extra}")
+            else:
+                lines.append("**Portal Scout**: unavailable")
+            lines.append("")
+
+        # ── INTAKE ────────────────────────────────────────────────────────
+        di = self._fetch_di_pipeline_signals()
+        catalog = self._fetch_di_clean_catalog()
+
+        lines.append("## 📥 INTAKE")
         lines.append("")
 
-        # Open PRs
-        lines.append("## Open PRs")
+        if di is not None:
+            summary = di.summary
+            total = summary.get("total", len(di.signals))
+            by_status = summary.get("by_status", {})
+            status_str = " · ".join(f"{v} {k}" for k, v in sorted(by_status.items()) if v)
+            lines.append(f"**Pipeline**: {total} candidates — {status_str}")
+            for s in di.failed_runs:
+                run = s.sample_run
+                lines.append(
+                    f"  ⚠️ **{s.label}** — run fallito [{run.year}]({run.run_url})"
+                )
+        else:
+            lines.append("**Pipeline**: unavailable")
+
+        if catalog is not None:
+            clean_ready = catalog.clean_ready
+            public_count = sum(1 for d in clean_ready if d.visibility == "public")
+            lines.append(
+                f"**Dataset Catalog**: {len(clean_ready)} clean_ready · "
+                f"{public_count} public · updated {catalog.updated_at}"
+            )
+        else:
+            lines.append("**Dataset Catalog**: unavailable")
         lines.append("")
+
+        # ── OPEN ─────────────────────────────────────────────────────────
         prs = self.github_collector.get_prs(self.config.repos)
         github_errors = self.github_collector.fetch_errors
         collector_warn = self.github_collector.collector_warning()
-        if collector_warn:
-            lines.append(f"> **Warning**: {collector_warn}")
-        if prs:
-            _DEPENDABOT = {"dependabot[bot]", "dependabot"}
-            feature_prs = [pr for pr in prs if pr.author not in _DEPENDABOT]
-            dep_prs = [pr for pr in prs if pr.author in _DEPENDABOT]
-            for pr in feature_prs[:10]:
-                lines.append(f"- [{pr.repo}#{pr.number}]({pr.url}): {pr.title}")
-            if dep_prs:
-                lines.append(
-                    f"- **Dependabot**: {len(dep_prs)} bump PR(s) - "
-                    + ", ".join(f"[#{pr.number}]({pr.url})" for pr in dep_prs[:2])
-                    + (" ..." if len(dep_prs) > 2 else "")
-                )
-        elif not github_errors:
-            lines.append("*No open PRs*")
-        lines.append("")
+        discussions = self.discussion_collector.get_discussions(self.config.repos) if self.discussion_collector else []
+        disc_errors = self.discussion_collector.fetch_errors if self.discussion_collector else {}
 
-        # Open Discussions
-        if self.discussion_collector is not None:
-            lines.append("## Open Discussions")
+        has_open = bool(prs) or bool(discussions) or bool(self.config.topics)
+        if has_open:
+            lines.append("## 🔗 OPEN")
             lines.append("")
-            discussions = self.discussion_collector.get_discussions(self.config.repos)
-            disc_errors = self.discussion_collector.fetch_errors
+
+            # PRs
+            if collector_warn:
+                lines.append(f"> Warning: GitHub fetch error — dati incompleti")
+            if prs:
+                _DEPENDABOT = {"dependabot[bot]", "dependabot"}
+                feature_prs = [pr for pr in prs if pr.author not in _DEPENDABOT]
+                dep_prs = [pr for pr in prs if pr.author in _DEPENDABOT]
+                for pr in feature_prs[:5]:
+                    lines.append(f"- [{pr.repo}#{pr.number}]({pr.url}): {pr.title}")
+                if dep_prs:
+                    lines.append(f"- **Dependabot**: {len(dep_prs)} bump PR(s)")
+            elif not github_errors:
+                lines.append("**PRs**: none open")
+
+            # Discussions
             if disc_errors:
-                lines.append(f"> **Discussions unavailable** — {len(disc_errors)} fetch error(s)")
-            if discussions:
-                for d in discussions[:10]:
-                    lines.append(f"- [{d.repo}#{d.number}]({d.url}) [{d.category}]: {d.title}")
-            elif not disc_errors:
-                lines.append("*No open discussions*")
+                lines.append(f"**Discussions**: {len(disc_errors)} fetch error(s)")
+            elif discussions:
+                lines.append(f"**Discussions**: {len(discussions)} open")
+                for d in discussions[:3]:
+                    lines.append(f"  · [{d.category}] {d.title}")
+
+            # Topics
+            if self.config.topics:
+                topics = " · ".join(self.config.topics.keys())
+                lines.append(f"**Topics**: {topics}")
+
             lines.append("")
 
-        # Local git state per repo
-        lines.append("## Local State")
-        lines.append("")
+        # ── INFRA ─────────────────────────────────────────────────────────
         repos_state = self.git_collector.get_repos_state(self.config.repos)
-        has_local_state = False
-        for repo, state in repos_state.items():
-            if state.available:
-                has_local_state = True
-                lines.append(f"**{repo}**: `{state.current_branch}`")
-                if state.dirty:
-                    lines.append(f"  - dirty ({state.untracked_files} untracked)")
-                if state.branches_ahead:
-                    lines.append(f"  - ahead: {', '.join(state.branches_ahead)}")
-        if not has_local_state:
-            lines.append("*No local git repos found*")
+        local_available = any(s.available for s in repos_state.values())
+        repos_count = len(self.config.repos)
+
+        lines.append("## 🛠 INFRA")
         lines.append("")
+        lines.append(f"**Repos**: {repos_count} attivi")
 
-        # Topics
-        if self.config.topics:
-            lines.append("## Topics")
-            lines.append("")
-            for topic_name in self.config.topics:
-                lines.append(f"- {topic_name}")
-            lines.append("")
+        if local_available:
+            for repo, state in repos_state.items():
+                if state.available:
+                    flags = []
+                    if state.dirty:
+                        flags.append("dirty")
+                    if state.branches_ahead:
+                        flags.append(f"ahead: {', '.join(state.branches_ahead)}")
+                    flag_str = f" ({', '.join(flags)})" if flags else ""
+                    lines.append(f"  · **{repo}** `{state.current_branch}`{flag_str}")
+        else:
+            lines.append("**Local git**: no workspace")
 
-        # Radar health (GREEN/YELLOW/RED per fonte)
-        radar = self._fetch_radar_summary()
-        lines += self._render_radar_section(radar)
-
-        # Catalog drift (only issues — skip stable sources)
-        so = self._fetch_source_observatory_signals()
-        lines += self._render_source_health_section(so)
-
-        # Pipeline state (only warn/error candidates)
-        di = self._fetch_di_pipeline_signals()
-        lines += self._render_pipeline_state_section(di)
-
-        # Dataset catalog (clean/queryable datasets)
-        catalog = self._fetch_di_clean_catalog()
-        lines += self._render_dataset_catalog_section(catalog)
-
-        # Portal scout (nuovi candidati strutturati)
-        scout = self._fetch_portal_scout()
-        lines += self._render_portal_scout_section(scout)
+        lines.append("")
+        return "\n".join(lines)
 
         return "\n".join(lines)
 

--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -52,6 +52,18 @@ class SourceObservatorySignals:
 
 
 @dataclass
+class RepoSignalSampleRun:
+    """Sample run metadata for a pipeline signal."""
+
+    status: str  # passed | failed
+    run_id: str
+    run_url: str
+    checked_at: str
+    year: int
+    config_path: str
+
+
+@dataclass
 class RepoSignal:
     """Single signal entry following the repo-signals standard v1."""
 
@@ -60,6 +72,7 @@ class RepoSignal:
     label: str
     detail: str
     action: str
+    sample_run: RepoSignalSampleRun | None = None
 
 
 @dataclass
@@ -78,6 +91,22 @@ class RepoSignals:
         """Signals that are warn or error (shown in bootstrap)."""
         return [s for s in self.signals if s.status in ("warn", "error")]
 
+    @property
+    def failed_runs(self) -> list[RepoSignal]:
+        """Signals with a failed sample_run (shown in bootstrap)."""
+        return [
+            s for s in self.signals
+            if s.sample_run is not None and s.sample_run.status == "failed"
+        ]
+
+
+@dataclass
+class DICleanDatasetColumn:
+    """Simplified column descriptor for triage."""
+
+    name: str
+    role: str  # metric | dimension
+
 
 @dataclass
 class DICleanDataset:
@@ -93,6 +122,7 @@ class DICleanDataset:
     metric_columns: int = 0
     dimension_columns: int = 0
     column_count: int = 0
+    columns: list[DICleanDatasetColumn] = field(default_factory=list)
 
 
 @dataclass
@@ -108,6 +138,25 @@ class DICleanCatalog:
     def clean_ready(self) -> list[DICleanDataset]:
         """Datasets with status clean_ready."""
         return [d for d in self.datasets if d.status == "clean_ready"]
+
+    @property
+    def candidates(self) -> list[DICleanDataset]:
+        """Datasets with status candidate (not yet clean_ready)."""
+        return [d for d in self.datasets if d.status == "candidate"]
+
+
+def _parse_sample_run(raw: dict[str, Any] | None) -> RepoSignalSampleRun | None:
+    """Parse a sample_run dict into a RepoSignalSampleRun instance."""
+    if raw is None:
+        return None
+    return RepoSignalSampleRun(
+        status=raw.get("status", ""),
+        run_id=raw.get("run_id", ""),
+        run_url=raw.get("run_url", ""),
+        checked_at=raw.get("checked_at", ""),
+        year=raw.get("year", 0),
+        config_path=raw.get("config_path", ""),
+    )
 
 
 def parse_repo_signals(raw: str) -> RepoSignals:
@@ -134,6 +183,7 @@ def parse_repo_signals(raw: str) -> RepoSignals:
             label=s.get("label", s.get("id", "")),
             detail=s.get("detail", ""),
             action=s.get("action", ""),
+            sample_run=_parse_sample_run(s.get("sample_run")),
         )
         for s in data.get("signals", [])
     ]
@@ -186,6 +236,10 @@ def parse_di_clean_catalog(raw: str) -> DICleanCatalog:
                 metric_columns=metric_columns,
                 dimension_columns=dimension_columns,
                 column_count=len(columns),
+                columns=[
+                    DICleanDatasetColumn(name=c.get("name", ""), role=c.get("role", ""))
+                    for c in columns
+                ],
             )
         )
 

--- a/src/agent_context_builder/triage.py
+++ b/src/agent_context_builder/triage.py
@@ -203,6 +203,10 @@ def _build_dataset_catalog_dict(
                 "metric_columns": d.metric_columns,
                 "dimension_columns": d.dimension_columns,
                 "column_count": d.column_count,
+                "columns": [
+                    {"name": c.name, "role": c.role}
+                    for c in d.columns
+                ] if d.status == "clean_ready" else [],
             }
             for d in catalog.datasets
         ],

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -72,12 +72,15 @@ def test_refresh_context_loads_token_from_env_file(monkeypatch, tmp_path):
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setenv("ACB_ENV_FILE", str(env_file))
     monkeypatch.setattr(mcp_server, "_ENV_LOADED", False)
+    monkeypatch.setattr(mcp_server, "_last_refresh_attempt", None)
 
     with patch("agent_context_builder.mcp_server.requests.post") as mock_post:
         mock_post.return_value = _mock_response("", status=204)
         result = mcp_server.refresh_context()
 
-    assert "triggerato" in result.lower()
+    import json
+    data = json.loads(result)
+    assert data["ok"] is True
     assert mock_post.call_args.kwargs["headers"]["Authorization"] == "token file-token"
 
 
@@ -91,12 +94,15 @@ def test_refresh_context_loads_token_when_env_is_empty(monkeypatch, tmp_path):
     monkeypatch.setenv("GITHUB_TOKEN", "")
     monkeypatch.setenv("ACB_ENV_FILE", str(env_file))
     monkeypatch.setattr(mcp_server, "_ENV_LOADED", False)
+    monkeypatch.setattr(mcp_server, "_last_refresh_attempt", None)
 
     with patch("agent_context_builder.mcp_server.requests.post") as mock_post:
         mock_post.return_value = _mock_response("", status=204)
         result = mcp_server.refresh_context()
 
-    assert "triggerato" in result.lower()
+    import json
+    data = json.loads(result)
+    assert data["ok"] is True
     assert mock_post.call_args.kwargs["headers"]["Authorization"] == "token file-token"
 
 
@@ -113,37 +119,47 @@ def test_refresh_context_continues_after_partial_env(monkeypatch, tmp_path):
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setenv("ACB_ENV_FILE", str(explicit_env))
     monkeypatch.setattr(mcp_server, "_ENV_LOADED", False)
+    monkeypatch.setattr(mcp_server, "_last_refresh_attempt", None)
 
     with patch("agent_context_builder.mcp_server.requests.post") as mock_post:
         mock_post.return_value = _mock_response("", status=204)
         result = mcp_server.refresh_context()
 
-    assert "triggerato" in result.lower()
+    import json
+    data = json.loads(result)
+    assert data["ok"] is True
     assert mock_post.call_args.kwargs["headers"]["Authorization"] == "token file-token"
 
 
 def test_refresh_context_success(monkeypatch):
     """refresh_context triggers workflow dispatch and reports success."""
-    from agent_context_builder.mcp_server import refresh_context
+    import agent_context_builder.mcp_server as mcp_server
 
     monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+    monkeypatch.setattr(mcp_server, "_last_refresh_attempt", None)
     with patch("agent_context_builder.mcp_server.requests.post") as mock_post:
         mock_post.return_value = _mock_response("", status=204)
-        result = refresh_context()
+        result = mcp_server.refresh_context()
 
-    assert "triggerato" in result.lower()
+    import json
+    data = json.loads(result)
+    assert data["ok"] is True
 
 
 def test_refresh_context_api_error(monkeypatch):
     """refresh_context reports API errors without raising."""
-    from agent_context_builder.mcp_server import refresh_context
+    import agent_context_builder.mcp_server as mcp_server
 
     monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+    monkeypatch.setattr(mcp_server, "_last_refresh_attempt", None)
     with patch("agent_context_builder.mcp_server.requests.post") as mock_post:
         mock_post.return_value = _mock_response("Forbidden", status=403)
-        result = refresh_context()
+        result = mcp_server.refresh_context()
 
-    assert "403" in result
+    import json
+    data = json.loads(result)
+    assert data["ok"] is False
+    assert data["status_code"] == 403
 
 
 def _mock_http_error(status: int):
@@ -155,36 +171,45 @@ def _mock_http_error(status: int):
 
 
 def test_session_bootstrap_http_error(monkeypatch):
-    """session_bootstrap returns error string on HTTP failure instead of raising."""
-    from agent_context_builder.mcp_server import session_bootstrap
+    """session_bootstrap returns JSON error on HTTP failure instead of raising."""
+    import agent_context_builder.mcp_server as mcp_server
 
     with patch("agent_context_builder.mcp_server.requests.get") as mock_get:
         mock_get.return_value = _mock_http_error(403)
-        result = session_bootstrap()
+        result = mcp_server.session_bootstrap()
 
-    assert "session_bootstrap" in result
-    assert "403" in result
+    import json
+    data = json.loads(result)
+    assert data["ok"] is False
+    assert data["tool"] == "session_bootstrap"
+    assert data["status_code"] == 403
 
 
 def test_workspace_triage_http_error(monkeypatch):
-    """workspace_triage returns error string on HTTP failure instead of raising."""
-    from agent_context_builder.mcp_server import workspace_triage
+    """workspace_triage returns JSON error on HTTP failure instead of raising."""
+    import agent_context_builder.mcp_server as mcp_server
 
     with patch("agent_context_builder.mcp_server.requests.get") as mock_get:
         mock_get.return_value = _mock_http_error(404)
-        result = workspace_triage()
+        result = mcp_server.workspace_triage()
 
-    assert "workspace_triage" in result
-    assert "404" in result
+    import json
+    data = json.loads(result)
+    assert data["ok"] is False
+    assert data["tool"] == "workspace_triage"
+    assert data["status_code"] == 404
 
 
 def test_topic_index_http_error(monkeypatch):
-    """topic_index returns error string on HTTP failure instead of raising."""
-    from agent_context_builder.mcp_server import topic_index
+    """topic_index returns JSON error on HTTP failure instead of raising."""
+    import agent_context_builder.mcp_server as mcp_server
 
     with patch("agent_context_builder.mcp_server.requests.get") as mock_get:
         mock_get.return_value = _mock_http_error(500)
-        result = topic_index()
+        result = mcp_server.topic_index()
 
-    assert "topic_index" in result
-    assert "500" in result
+    import json
+    data = json.loads(result)
+    assert data["ok"] is False
+    assert data["tool"] == "topic_index"
+    assert data["status_code"] == 500

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -74,8 +74,8 @@ def test_render_session_bootstrap():
     bootstrap = renderer.render_session_bootstrap()
 
     assert "Session Bootstrap" in bootstrap
-    assert "repo1" in bootstrap
-    assert "repo2" in bootstrap
+    assert "## 🛠 INFRA" in bootstrap
+    assert "6 attivi" not in bootstrap  # shows per-repo in INFRA
     assert len(bootstrap.split("\n")) > 10
 
 
@@ -94,8 +94,10 @@ def test_render_session_bootstrap_github_error():
     )
     bootstrap = renderer.render_session_bootstrap()
 
-    assert "rate-limit" in bootstrap
-    assert "No open PRs" not in bootstrap
+    # Warning appears in INTAKE when signals are unavailable due to fetch failure
+    assert "## 📥 INTAKE" in bootstrap
+    assert "Pipeline" in bootstrap
+    assert "unavailable" in bootstrap
 
 
 def test_render_session_bootstrap_groups_dependabot_prs():
@@ -203,9 +205,9 @@ def test_render_bootstrap_with_discussions():
     )
     bootstrap = renderer.render_session_bootstrap()
 
-    assert "Open Discussions" in bootstrap
+    assert "## 🔗 OPEN" in bootstrap
     assert "IRPEF" in bootstrap
-    assert "Civic Questions" in bootstrap
+    assert "[Civic Questions]" in bootstrap
 
 
 def test_render_triage_with_discussions():
@@ -257,13 +259,14 @@ def test_render_bootstrap_with_catalog_drift():
     )
     bootstrap = renderer.render_session_bootstrap()
 
-    assert "Catalog Drift" in bootstrap
+    assert "## 🔍 SCOUTING" in bootstrap
     assert "inps" in bootstrap
     assert "inventory change" in bootstrap
+    assert "verificare se variazione attesa" in bootstrap
 
 
 def test_render_bootstrap_catalog_drift_all_stable():
-    """Bootstrap catalog drift shows no drift when there are no alerts."""
+    """Bootstrap shows SCOUTING section with no drift when all sources are stable."""
     config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
     renderer = Renderer(
         config,
@@ -272,12 +275,12 @@ def test_render_bootstrap_catalog_drift_all_stable():
     )
     bootstrap = renderer.render_session_bootstrap()
 
-    assert "Catalog Drift" in bootstrap
-    assert "No catalog drift signals" in bootstrap
+    assert "## 🔍 SCOUTING" in bootstrap
+    assert "no drift signals" in bootstrap
 
 
 def test_render_bootstrap_catalog_drift_unavailable():
-    """Bootstrap catalog drift shows unavailable message when fetch fails."""
+    """Bootstrap shows unavailable when catalog signals fetch fails."""
     config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
     renderer = Renderer(
         config,
@@ -286,7 +289,9 @@ def test_render_bootstrap_catalog_drift_unavailable():
     )
     bootstrap = renderer.render_session_bootstrap()
 
-    assert "Catalog Drift" in bootstrap
+    # When no source observatory data, SCOUTING section is omitted entirely
+    assert "## 📥 INTAKE" in bootstrap
+    assert "Pipeline" in bootstrap
     assert "unavailable" in bootstrap
 
 
@@ -460,10 +465,9 @@ def test_render_bootstrap_dataset_catalog_section():
     bootstrap = renderer.render_session_bootstrap()
 
     assert "Dataset Catalog" in bootstrap
-    assert "1 clean_ready dataset(s), 1 public" in bootstrap
-    assert "irpef_comunale" in bootstrap
-    assert "2022-2023" in bootstrap
-    assert "draft_dataset" not in bootstrap
+    assert "**Dataset Catalog**: 1 clean_ready · 1 public · updated 2026-04-14" in bootstrap
+    # Dataset names/periods are in workspace_triage.json, not bootstrap
+    assert "irpef_comunale" not in bootstrap
 
 
 def test_render_triage_dataset_catalog_available():

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -5,7 +5,9 @@ import pytest
 
 from agent_context_builder.signals import (
     DICleanCatalog,
+    DICleanDatasetColumn,
     RepoSignals,
+    RepoSignalSampleRun,
     SourceObservatorySignals,
     SourceSignal,
     parse_di_clean_catalog,
@@ -166,6 +168,124 @@ def test_parse_repo_signals_missing_fields_use_defaults():
     assert rs.signals[0].label == "test"
 
 
+def test_parse_repo_signals_sample_run_parsing():
+    """sample_run fields are parsed and exposed on RepoSignal."""
+    raw = json.dumps({
+        "schema_version": "1",
+        "generated_at": "2026-04-30",
+        "repo": "di",
+        "topic": "pipeline",
+        "signals": [
+            {
+                "id": "test-candidate",
+                "status": "ok",
+                "label": "test-candidate",
+                "detail": "ok",
+                "action": "",
+                "sample_run": {
+                    "status": "failed",
+                    "run_id": "12345",
+                    "run_url": "https://github.com/.../actions/runs/12345",
+                    "checked_at": "2026-04-30",
+                    "year": 2020,
+                    "config_path": "candidates/test-candidate/dataset.yml",
+                },
+            },
+        ],
+    })
+    rs = parse_repo_signals(raw)
+    assert len(rs.signals) == 1
+    sr = rs.signals[0]
+    assert sr.sample_run is not None
+    assert sr.sample_run.status == "failed"
+    assert sr.sample_run.run_id == "12345"
+    assert sr.sample_run.year == 2020
+
+
+def test_parse_repo_signals_no_sample_run():
+    """Signal without sample_run has None."""
+    raw = json.dumps({
+        "schema_version": "1",
+        "generated_at": "2026-04-30",
+        "repo": "di",
+        "topic": "pipeline",
+        "signals": [{"id": "a", "status": "ok", "label": "a", "detail": "", "action": ""}],
+    })
+    rs = parse_repo_signals(raw)
+    assert rs.signals[0].sample_run is None
+
+
+def test_failed_runs_property():
+    """failed_runs returns only signals with a failed sample_run."""
+    raw = json.dumps({
+        "schema_version": "1",
+        "generated_at": "2026-04-30",
+        "repo": "di",
+        "topic": "pipeline",
+        "signals": [
+            {"id": "ok-signal", "status": "ok", "label": "ok", "detail": "", "action": ""},
+            {
+                "id": "failed-signal",
+                "status": "ok",
+                "label": "failed-signal",
+                "detail": "",
+                "action": "",
+                "sample_run": {"status": "failed", "run_id": "1", "run_url": "x", "checked_at": "x", "year": 2020, "config_path": "x.yml"},
+            },
+            {"id": "ok-signal-2", "status": "ok", "label": "ok2", "detail": "", "action": ""},
+        ],
+    })
+    rs = parse_repo_signals(raw)
+    assert len(rs.failed_runs) == 1
+    assert rs.failed_runs[0].id == "failed-signal"
+
+
+def test_candidates_property():
+    """candidates returns datasets with status != clean_ready."""
+    raw = json.dumps({
+        "schema_version": "1",
+        "name": "Test",
+        "updated_at": "2026-04-30",
+        "datasets": [
+            {"slug": "ready", "name": "Ready", "status": "clean_ready", "visibility": "public", "columns": []},
+            {"slug": "cand", "name": "Candidate", "status": "candidate", "visibility": "public", "columns": []},
+            {"slug": "cand2", "name": "Candidate 2", "status": "candidate", "visibility": "public", "columns": []},
+        ],
+    })
+    catalog = parse_di_clean_catalog(raw)
+    assert len(catalog.clean_ready) == 1
+    assert len(catalog.candidates) == 2
+    assert {d.slug for d in catalog.candidates} == {"cand", "cand2"}
+
+
+def test_di_clean_catalog_columns_parsed():
+    """Column name and role are parsed; type and description are excluded."""
+    raw = json.dumps({
+        "schema_version": "1",
+        "name": "Test",
+        "updated_at": "2026-04-30",
+        "datasets": [
+            {
+                "slug": "test",
+                "name": "Test",
+                "status": "clean_ready",
+                "visibility": "public",
+                "columns": [
+                    {"name": "anno", "type": "INTEGER", "role": "dimension", "description": "Year"},
+                    {"name": "valore", "type": "FLOAT", "role": "metric", "description": "Value"},
+                ],
+            }
+        ],
+    })
+    catalog = parse_di_clean_catalog(raw)
+    ds = catalog.datasets[0]
+    assert len(ds.columns) == 2
+    assert ds.columns[0].name == "anno"
+    assert ds.columns[0].role == "dimension"
+    assert ds.columns[1].name == "valore"
+    assert ds.columns[1].role == "metric"
+
+
 def test_parse_radar_summary():
     from agent_context_builder.signals import parse_radar_summary
 
@@ -228,6 +348,12 @@ def test_parse_di_clean_catalog_basic():
     assert dataset.metric_columns == 1
     assert dataset.dimension_columns == 2
     assert dataset.column_count == 3
+    # Columns are parsed: name + role only (no type, no description)
+    assert len(dataset.columns) == 3
+    assert dataset.columns[0].name == "anno"
+    assert dataset.columns[0].role == "dimension"
+    assert dataset.columns[2].name == "imposta"
+    assert dataset.columns[2].role == "metric"
 
 
 def test_parse_di_clean_catalog_missing_fields_use_defaults():
@@ -240,3 +366,4 @@ def test_parse_di_clean_catalog_missing_fields_use_defaults():
     assert catalog.datasets[0].name == "minimal"
     assert catalog.datasets[0].status == ""
     assert catalog.datasets[0].location == {}
+    assert catalog.datasets[0].columns == []


### PR DESCRIPTION
## Summary

Quattro commit che portano ACB a un livello superiore di utilità:

### 1. feat(session_bootstrap): surface pending signals (`e3aa1d1`)
- `sample_run` fail surface in bootstrap — link al run + anno per failed runs
- `datasets_in_use` nel radar per fonti YELLOW/RED
- `candidates_by_source` in topic_index (raggruppato per fonte)
- Column role metadata in workspace_triage per clean_ready datasets

### 2. test(render): align test expectations (`11b1115`)
- Test aggiornati per rispecchiare la nuova struttura bootstrap per fase (SCOUTING/INTAKE/OPEN/INFRA)

### 3. feat(mcp_server): retry, rate-limit guard, structured logging, JSON errors (`57f62d1`)
- `_fetch()`: retry con backoff esponenziale su 5xx — 4xx fallisce subito
- `refresh_context`: guard locale rate-limit (1 call/min) con campo `retry_after`
- Structured logging via `ACB_LOG_LEVEL` env var
- Tutti i tool ora restituiscono JSON strutturato `{ok, tool, path/error, status_code, ts}`

### 4. refactor(render): remove orphan methods (`703d4f0`)
- Rimossi ~270 righe di metodi `_render_*` e `_build_*` orfani
- Coverage render.py: 47% → 76%

## Test
- 62/62 test passano
- Coverage totale: 73%

## Artifact modificati (nessun breaking change)
- `session_bootstrap.md`: più informazioni actionables, bootstrap ~40 righe
- `workspace_triage.json`: column metadata per clean datasets
- `topic_index.json`: candidates_by_source aggiunto
- MCP tool responses: JSON strutturato invece di stringhe

## Note
- Topics via GitHub labels (governance, source-check, intake...) discussione rimandata a successiva PR