### PR TITLE
feat(radar): enrich ACB radar data with persistent_red, note and red_streak

### DIFF
--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -79,11 +79,15 @@ class Renderer:
                     f"GREEN {radar.green} · YELLOW {radar.yellow} · RED {radar.red} "
                     f"(probe: {radar.probe_date})"
                 )
+                if radar.persistent_red:
+                    lines.append(f"  ⚠ **{radar.persistent_red} persistent RED**")
                 if radar.unhealthy:
                     for s in radar.unhealthy:
                         di = f" — ↳ {', '.join(s.datasets_in_use)}" if s.datasets_in_use else ""
+                        streak = f" (streak {s.red_streak})" if s.red_streak else ""
+                        note = f" — {s.note}" if s.note else ""
                         lines.append(
-                            f"  · **{s.id}** {s.status} [{s.http_code}]{di}"
+                            f"  · **{s.id}** {s.status} [{s.http_code}]{note}{streak}{di}"
                         )
             else:
                 lines.append("**Radar**: unavailable")

--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -298,6 +298,8 @@ class RadarSource:
     http_code: str
     last_check: str
     datasets_in_use: list[str] = field(default_factory=list)
+    note: str | None = None
+    red_streak: int = 0
 
 
 @dataclass
@@ -310,6 +312,7 @@ class RadarSummary:
     green: int
     yellow: int
     red: int
+    persistent_red: int = 0
     sources: list[RadarSource] = field(default_factory=list)
 
     @property
@@ -333,6 +336,8 @@ def parse_radar_summary(raw: str) -> RadarSummary:
             http_code=s.get("http_code", "-"),
             last_check=s.get("last_check", ""),
             datasets_in_use=s.get("datasets_in_use") or [],
+            note=s.get("note"),
+            red_streak=s.get("red_streak", 0),
         )
         for s in data.get("sources", [])
     ]
@@ -344,6 +349,7 @@ def parse_radar_summary(raw: str) -> RadarSummary:
         green=counts.get("GREEN", 0),
         yellow=counts.get("YELLOW", 0),
         red=counts.get("RED", 0),
+        persistent_red=data.get("persistent_red", 0),
         sources=sources,
     )
 

--- a/src/agent_context_builder/triage.py
+++ b/src/agent_context_builder/triage.py
@@ -101,8 +101,16 @@ def _build_radar_dict(fetcher: SourceObservatoryFetcher) -> dict[str, Any]:
         "green": radar.green,
         "yellow": radar.yellow,
         "red": radar.red,
+        "persistent_red": radar.persistent_red,
         "unhealthy": [
-            {"id": s.id, "status": s.status, "protocol": s.protocol, "http_code": s.http_code}
+            {
+                "id": s.id,
+                "status": s.status,
+                "protocol": s.protocol,
+                "http_code": s.http_code,
+                "note": s.note,
+                "red_streak": s.red_streak,
+            }
             for s in radar.unhealthy
         ],
     }

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -294,6 +294,7 @@ def test_parse_radar_summary():
         "probe_date": "2026-04-19",
         "sources_total": 3,
         "status_counts": {"GREEN": 2, "YELLOW": 1, "RED": 0},
+        "persistent_red": 1,
         "sources": [
             {"id": "inps", "status": "GREEN", "protocol": "ckan",
              "observation_mode": "catalog-watch", "http_code": "200",
@@ -301,6 +302,10 @@ def test_parse_radar_summary():
             {"id": "anac", "status": "YELLOW", "protocol": "ckan",
              "observation_mode": "radar-only", "http_code": "200",
              "last_check": "2026-04-19", "datasets_in_use": []},
+            {"id": "dati_salute", "status": "RED", "protocol": "html",
+             "observation_mode": "radar-only", "http_code": "-",
+             "last_check": "2026-04-19", "datasets_in_use": [],
+             "note": "SSL verify failed", "red_streak": 2},
             {"id": "istat", "status": "GREEN", "protocol": "sdmx",
              "observation_mode": "catalog-watch", "http_code": "200",
              "last_check": "2026-04-19", "datasets_in_use": []},
@@ -311,8 +316,12 @@ def test_parse_radar_summary():
     assert summary.green == 2
     assert summary.yellow == 1
     assert summary.red == 0
-    assert len(summary.unhealthy) == 1
+    assert summary.persistent_red == 1
+    assert len(summary.unhealthy) == 2
     assert summary.unhealthy[0].id == "anac"
+    assert summary.unhealthy[1].id == "dati_salute"
+    assert summary.unhealthy[1].note == "SSL verify failed"
+    assert summary.unhealthy[1].red_streak == 2
 
 
 def test_parse_di_clean_catalog_basic():


### PR DESCRIPTION
## Summary

Aggiunge informazioni strutturate dal SO radar che erano già disponibili ma non esposte da ACB.

### Changes

**signals.py**
- `RadarSummary`: aggiunge `persistent_red: int` — count fonti RED persistenti (quelle con red_streak > 0)
- `RadarSource`: aggiunge `note: str | None` e `red_streak: int` — dettaglio per fonte

**triage.py**
- `_build_radar_dict()`: include `persistent_red` a livello radar, `note` e `red_streak` per ogni fonte unhealthy

**render.py**
- Bootstrap: mostra `⚠ {n} persistent RED` quando ci sono fonti RED persistenti
- Per ogni fonte unhealthy mostra nota e streak se presenti

**tests**
- `test_parse_radar_summary`: cover nuovi campi

### Artifact aggiornati

**session_bootstrap.md**
```
**Radar**: 14 fonti — GREEN 9 · YELLOW 3 · RED 2 (probe: 2026-05-03)
  ⚠ **2 persistent RED**
  · dati_salute RED [-] — SSL verify failed (streak 2)
```

**workspace_triage.json**
```json
{
  "radar": {
    "persistent_red": 2,
    "unhealthy": [{
      "id": "dati_salute",
      "note": "SSL verify failed",
      "red_streak": 2
    }]
  }
}
```

## Test

62/62 test passano · Coverage: 72%

## Note

- Topic registry (SO sources per topic) non implementato — manca la fonte del mapping
- Delta probe-to-probe non implementato — richiede nuovo fetcher e logica