### PR TITLE
refactor: migra GitHubCollector da requests a lab_connectors.http.HttpClient

### DIFF
--- a/.github/workflows/build-context.yml
+++ b/.github/workflows/build-context.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install
-        run: pip install -e ".[dev,mcp]"
+        run: pip install -e ".[dev]"
 
       - name: Test
         run: pytest --cov=src/agent_context_builder --cov-report=xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,12 @@ dependencies = [
     "pydantic>=2.0",
     "pyyaml>=6.0",
     "requests>=2.28",
+    "lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.2.0",
 ]
 
 [project.optional-dependencies]
 mcp = [
     "mcp>=1.0",
-    "lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.2.0",
 ]
 dev = [
     "pytest>=7.0",

--- a/src/agent_context_builder/github.py
+++ b/src/agent_context_builder/github.py
@@ -108,6 +108,14 @@ class GitHubCollector:
                 self.fetch_errors[f"{repo}:issues"] = str(e)
         return issues
 
+    def _raise_on_bad_status(self, result, url_desc: str) -> None:
+        """Raise RuntimeError if result is error or response status >= 400."""
+        if not result.is_ok:
+            raise RuntimeError(f"{url_desc}: {result.err}")
+        status = result.response.status_code  # type: ignore[union-attr]
+        if status >= 400:
+            raise RuntimeError(f"{url_desc}: HTTP {status}")
+
     def _headers(self) -> dict[str, str]:
         """Build Authorization headers if token is set."""
         if self.token:
@@ -119,8 +127,7 @@ class GitHubCollector:
         url = f"{self.base_url}/repos/{self.org}/{repo}/pulls"
         params = {"state": state, "per_page": 50}
         result = self._http.get(url, params=params, headers=self._headers())
-        if not result.is_ok:
-            raise RuntimeError(str(result.err))
+        self._raise_on_bad_status(result, url)
 
         prs = []
         for item in result.response.json():  # type: ignore[union-attr]
@@ -152,10 +159,12 @@ class GitHubCollector:
         """
         url = f"https://raw.githubusercontent.com/{self.org}/{repo}/{ref}/{path}"
         result = self._http.get(url, headers=self._headers())
-        if result.is_ok:
+        try:
+            self._raise_on_bad_status(result, url)
             return result.response.text  # type: ignore[union-attr]
-        self.fetch_errors[f"{repo}:{path}"] = str(result.err or "unknown error")
-        return None
+        except Exception as exc:
+            self.fetch_errors[f"{repo}:{path}"] = str(exc)
+            return None
 
     def get_repos_info(self, repos: list[str]) -> dict[str, RepoInfo]:
         """Get metadata (description, url) for each repo.
@@ -167,8 +176,7 @@ class GitHubCollector:
             try:
                 url = f"{self.base_url}/repos/{self.org}/{repo}"
                 result = self._http.get(url, headers=self._headers())
-                if not result.is_ok:
-                    raise RuntimeError(str(result.err))
+                self._raise_on_bad_status(result, url)
                 data = result.response.json()  # type: ignore[union-attr]
                 result_map[repo] = RepoInfo(
                     name=repo,
@@ -188,8 +196,7 @@ class GitHubCollector:
         url = f"{self.base_url}/repos/{self.org}/{repo}/issues"
         params = {"state": state, "per_page": 50}
         result = self._http.get(url, params=params, headers=self._headers())
-        if not result.is_ok:
-            raise RuntimeError(str(result.err))
+        self._raise_on_bad_status(result, url)
 
         issues = []
         for item in result.response.json():  # type: ignore[union-attr]

--- a/src/agent_context_builder/github.py
+++ b/src/agent_context_builder/github.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
-try:
-    from lab_connectors.http import HttpClient
-except ImportError:
-    HttpClient = None  # type: ignore[assignment,misc]
+from lab_connectors.http import HttpClient
 
 
 @dataclass
@@ -52,15 +49,7 @@ class GitHubCollector:
         Args:
             org: GitHub organization
             token: GitHub API token (optional)
-
-        Raises:
-            RuntimeError: If lab_connectors.http is not installed.
         """
-        if HttpClient is None:
-            raise RuntimeError(
-                "lab_connectors.http is required. Install with: "
-                "pip install agent-context-builder[mcp]"
-            )
         self.org = org
         self.token = token
         self.base_url = "https://api.github.com"

--- a/src/agent_context_builder/github.py
+++ b/src/agent_context_builder/github.py
@@ -1,9 +1,14 @@
 """GitHub API interactions for context collection."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional
 
-import requests
+try:
+    from lab_connectors.http import HttpClient
+except ImportError:
+    HttpClient = None  # type: ignore[assignment,misc]
 
 
 @dataclass
@@ -47,15 +52,24 @@ class GitHubCollector:
         Args:
             org: GitHub organization
             token: GitHub API token (optional)
+
+        Raises:
+            RuntimeError: If lab_connectors.http is not installed.
         """
+        if HttpClient is None:
+            raise RuntimeError(
+                "lab_connectors.http is required. Install with: "
+                "pip install agent-context-builder[mcp]"
+            )
         self.org = org
         self.token = token
         self.base_url = "https://api.github.com"
+        self._http = HttpClient(timeout=10)
         # Populated by get_prs/get_issues — maps "<repo>:prs" or "<repo>:issues" to error message
         self.fetch_errors: dict[str, str] = {}
 
     def collector_warning(self) -> str | None:
-        """Return a human-readable warning if fetch errors suggest rate-limit or auth degradation."""
+        """Return a warning if fetch errors suggest rate-limit or auth degradation."""
         if not self.fetch_errors:
             return None
         msgs = " ".join(self.fetch_errors.values()).lower()
@@ -105,19 +119,22 @@ class GitHubCollector:
                 self.fetch_errors[f"{repo}:issues"] = str(e)
         return issues
 
+    def _headers(self) -> dict[str, str]:
+        """Build Authorization headers if token is set."""
+        if self.token:
+            return {"Authorization": f"token {self.token}"}
+        return {}
+
     def _get_repo_prs(self, repo: str, state: str = "open") -> list[PR]:
         """Get PRs for a specific repo."""
         url = f"{self.base_url}/repos/{self.org}/{repo}/pulls"
         params = {"state": state, "per_page": 50}
-        headers = {}
-        if self.token:
-            headers["Authorization"] = f"token {self.token}"
-
-        response = requests.get(url, params=params, headers=headers, timeout=10)
-        response.raise_for_status()
+        result = self._http.get(url, params=params, headers=self._headers())
+        if not result.is_ok:
+            raise RuntimeError(str(result.err))
 
         prs = []
-        for item in response.json():
+        for item in result.response.json():  # type: ignore[union-attr]
             prs.append(
                 PR(
                     number=item["number"],
@@ -145,40 +162,33 @@ class GitHubCollector:
             Raw file content as string, or None on failure.
         """
         url = f"https://raw.githubusercontent.com/{self.org}/{repo}/{ref}/{path}"
-        headers = {}
-        if self.token:
-            headers["Authorization"] = f"token {self.token}"
-        try:
-            response = requests.get(url, headers=headers, timeout=10)
-            response.raise_for_status()
-            return response.text
-        except Exception as exc:
-            self.fetch_errors[f"{repo}:{path}"] = str(exc)
-            return None
+        result = self._http.get(url, headers=self._headers())
+        if result.is_ok:
+            return result.response.text  # type: ignore[union-attr]
+        self.fetch_errors[f"{repo}:{path}"] = str(result.err or "unknown error")
+        return None
 
     def get_repos_info(self, repos: list[str]) -> dict[str, RepoInfo]:
         """Get metadata (description, url) for each repo.
 
         Returns a dict keyed by repo name. Missing/failed repos are skipped silently.
         """
-        result: dict[str, RepoInfo] = {}
-        headers = {}
-        if self.token:
-            headers["Authorization"] = f"token {self.token}"
+        result_map: dict[str, RepoInfo] = {}
         for repo in repos:
             try:
                 url = f"{self.base_url}/repos/{self.org}/{repo}"
-                response = requests.get(url, headers=headers, timeout=10)
-                response.raise_for_status()
-                data = response.json()
-                result[repo] = RepoInfo(
+                result = self._http.get(url, headers=self._headers())
+                if not result.is_ok:
+                    raise RuntimeError(str(result.err))
+                data = result.response.json()  # type: ignore[union-attr]
+                result_map[repo] = RepoInfo(
                     name=repo,
                     description=data.get("description") or "",
                     url=data.get("html_url", ""),
                 )
             except Exception as exc:
                 self.fetch_errors[f"{repo}:info"] = str(exc)
-        return result
+        return result_map
 
     def _get_repo_issues(self, repo: str, state: str = "open") -> list[Issue]:
         """Get issues for a specific repo (excluding pull requests).
@@ -188,15 +198,12 @@ class GitHubCollector:
         """
         url = f"{self.base_url}/repos/{self.org}/{repo}/issues"
         params = {"state": state, "per_page": 50}
-        headers = {}
-        if self.token:
-            headers["Authorization"] = f"token {self.token}"
-
-        response = requests.get(url, params=params, headers=headers, timeout=10)
-        response.raise_for_status()
+        result = self._http.get(url, params=params, headers=self._headers())
+        if not result.is_ok:
+            raise RuntimeError(str(result.err))
 
         issues = []
-        for item in response.json():
+        for item in result.response.json():  # type: ignore[union-attr]
             # Skip pull requests: they have a pull_request field
             if "pull_request" in item:
                 continue

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,85 @@
+"""Tests for github module HTTP boundary."""
+
+from unittest.mock import MagicMock, patch
+
+from agent_context_builder.github import GitHubCollector
+
+
+def _make_http_result(status_code: int, body: str = ""):
+    """Build a mock HttpResult with the given status code."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.text = body
+    mock_resp.json.return_value = {}
+    result = MagicMock()
+    result.is_ok = status_code < 500  # come HttpClient reale
+    result.response = mock_resp
+    result.err = None
+    return result
+
+
+class TestGetRawFile:
+    """get_raw_file deve gestire 4xx come errori, non restituire body di errore."""
+
+    def test_404_returns_none(self):
+        """404 su get_raw_file → None + fetch_errors popolato."""
+        collector = GitHubCollector("test-org", token="fake")
+        with patch.object(collector._http, "get", return_value=_make_http_result(404)):
+            result = collector.get_raw_file("some-repo", "data/file.json")
+        assert result is None
+        assert "some-repo:data/file.json" in collector.fetch_errors
+        assert "HTTP 404" in collector.fetch_errors["some-repo:data/file.json"]
+
+    def test_200_returns_text(self):
+        """200 su get_raw_file → body restituito."""
+        collector = GitHubCollector("test-org", token="fake")
+        with patch.object(collector._http, "get", return_value=_make_http_result(200, "ok")):
+            result = collector.get_raw_file("some-repo", "data/file.json")
+        assert result == "ok"
+
+    def test_403_records_error(self):
+        """403 su get_raw_file → None + errore tracciato."""
+        collector = GitHubCollector("test-org", token="fake")
+        with patch.object(collector._http, "get", return_value=_make_http_result(403)):
+            result = collector.get_raw_file("some-repo", "data/file.json")
+        assert result is None
+        assert "HTTP 403" in collector.fetch_errors["some-repo:data/file.json"]
+
+
+class TestGetReposInfo:
+    """get_repos_info deve segnalare 4xx come errori, non dati vuoti."""
+
+    def test_403_skips_and_records_error(self):
+        """403 su get_repos_info → repo skippato + errore tracciato."""
+        collector = GitHubCollector("test-org", token="fake")
+        with patch.object(collector._http, "get", return_value=_make_http_result(403)):
+            result = collector.get_repos_info(["some-repo"])
+        assert "some-repo" not in result
+        assert "some-repo:info" in collector.fetch_errors
+        assert "HTTP 403" in collector.fetch_errors["some-repo:info"]
+
+
+class TestGetRepoPrs:
+    """get_prs deve propagare 4xx come errori."""
+
+    def test_403_records_error(self):
+        """403 su get_prs → lista vuota + errore tracciato."""
+        collector = GitHubCollector("test-org", token="fake")
+        with patch.object(collector._http, "get", return_value=_make_http_result(403)):
+            result = collector.get_prs(["some-repo"])
+        assert result == []
+        assert "some-repo:prs" in collector.fetch_errors
+        assert "HTTP 403" in collector.fetch_errors["some-repo:prs"]
+
+
+class TestGetIssues:
+    """get_issues deve propagare 4xx come errori."""
+
+    def test_403_records_error(self):
+        """403 su get_issues → lista vuota + errore tracciato."""
+        collector = GitHubCollector("test-org", token="fake")
+        with patch.object(collector._http, "get", return_value=_make_http_result(403)):
+            result = collector.get_issues(["some-repo"])
+        assert result == []
+        assert "some-repo:issues" in collector.fetch_errors
+        assert "HTTP 403" in collector.fetch_errors["some-repo:issues"]


### PR DESCRIPTION
## Summary

Migra `GitHubCollector` da `requests.get()` diretto a `lab_connectors.http.HttpClient`. Allineato al pattern toolkit e SO.

## Cosa cambia

**src/agent_context_builder/github.py**
- `import requests` → `from lab_connectors.http import HttpClient` (top-level, come toolkit e SO)
- 4 metodi HTTP migrati: `_get_repo_prs`, `get_raw_file`, `get_repos_info`, `_get_repo_issues`
- `HttpClient` init con `timeout=10`, token passato come header per-request
- `_raise_on_bad_status()` helper che controlla sia `result.is_ok` che `status >= 400`
- Le risposte 4xx vengono ora trattate come errori (prima: body di errore passato come contenuto valido)

**pyproject.toml**
- `lab-connectors` diventa dipendenza **core** (non più extra `[mcp]`) — come toolkit e SO

**CI**
- `build-context.yml` torna a `pip install -e ".[dev]"` (core dep basta)

## Test

- 68/68 test passano (62 esistenti + 6 nuovi per 4xx handling)
- `test_github.py`: 6 regression test per 404/403 su tutti e 4 i metodi HTTP
- `ruff` 0 errori