### PR TITLE
feat: contesto data-explorer — temi, gap analysis, deploy status

### DIFF
--- a/src/agent_context_builder/github.py
+++ b/src/agent_context_builder/github.py
@@ -188,20 +188,36 @@ class GitHubCollector:
         return result_map
 
     def get_latest_workflow_run(
-        self, repo: str, event: str = "push", status: str = "completed"
+        self,
+        repo: str,
+        event: str = "push",
+        status: str = "completed",
+        workflow_id: str | None = None,
     ) -> dict[str, Any] | None:
         """Fetch the latest workflow run for a repo.
+
+        If workflow_id is provided, uses the workflow-specific endpoint
+        (e.g. ``deploy.yml``) to avoid ambiguity when multiple workflows
+        trigger on the same event.
 
         Args:
             repo: Repository name (under self.org)
             event: Event type filter (e.g. push, workflow_dispatch)
             status: Status filter (e.g. completed, success)
+            workflow_id: Workflow filename (e.g. ``deploy.yml``) for
+                         precise targeting. Optional.
 
         Returns:
             Dict with run_id, name, status, conclusion, started_at, completed_at, html_url,
             or None if no runs found or on error.
         """
-        url = f"{self.base_url}/repos/{self.org}/{repo}/actions/runs"
+        if workflow_id:
+            url = (
+                f"{self.base_url}/repos/{self.org}/{repo}"
+                f"/actions/workflows/{workflow_id}/runs"
+            )
+        else:
+            url = f"{self.base_url}/repos/{self.org}/{repo}/actions/runs"
         params = {
             "event": event,
             "status": status,

--- a/src/agent_context_builder/github.py
+++ b/src/agent_context_builder/github.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 from lab_connectors.http import HttpClient
 
@@ -186,6 +186,47 @@ class GitHubCollector:
             except Exception as exc:
                 self.fetch_errors[f"{repo}:info"] = str(exc)
         return result_map
+
+    def get_latest_workflow_run(
+        self, repo: str, event: str = "push", status: str = "completed"
+    ) -> dict[str, Any] | None:
+        """Fetch the latest workflow run for a repo.
+
+        Args:
+            repo: Repository name (under self.org)
+            event: Event type filter (e.g. push, workflow_dispatch)
+            status: Status filter (e.g. completed, success)
+
+        Returns:
+            Dict with run_id, name, status, conclusion, started_at, completed_at, html_url,
+            or None if no runs found or on error.
+        """
+        url = f"{self.base_url}/repos/{self.org}/{repo}/actions/runs"
+        params = {
+            "event": event,
+            "status": status,
+            "per_page": 1,
+        }
+        try:
+            result = self._http.get(url, params=params, headers=self._headers())
+            self._raise_on_bad_status(result, url)
+            data = result.response.json()  # type: ignore[union-attr]
+            runs = data.get("workflow_runs", [])
+            if not runs:
+                return None
+            run = runs[0]
+            return {
+                "run_id": run.get("id"),
+                "name": run.get("name", ""),
+                "status": run.get("status", ""),
+                "conclusion": run.get("conclusion"),
+                "started_at": run.get("run_started_at", ""),
+                "completed_at": run.get("updated_at", ""),
+                "html_url": run.get("html_url", ""),
+            }
+        except Exception as exc:
+            self.fetch_errors[f"{repo}:workflow_runs"] = str(exc)
+            return None
 
     def _get_repo_issues(self, repo: str, state: str = "open") -> list[Issue]:
         """Get issues for a specific repo (excluding pull requests).

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -171,6 +171,18 @@ class Renderer:
                     lines.append(f"    · {slug}")
                 if len(gap) > 5:
                     lines.append(f"    · ... e altri {len(gap) - 5}")
+
+            # Deploy status
+            last_deploy = self._de_fetcher.fetch_deploy_status()
+            if last_deploy is not None:
+                conclusion = last_deploy.get("conclusion", "unknown")
+                icon = "✅" if conclusion == "success" else "❌"
+                completed = (last_deploy.get("completed_at", "")[:10]
+                             if last_deploy.get("completed_at") else "?")
+                lines.append(f"  **Deploy**: {icon} {conclusion} ({completed})")
+            else:
+                lines.append(f"  **Deploy**: dati non disponibili")
+
             lines.append("")
 
         # ── OPEN ─────────────────────────────────────────────────────────

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -9,9 +9,11 @@ from .config import Config
 from .discussions import DiscussionCollector
 from .github import GitHubCollector, PR
 from .git_local import GitLocalCollector, GitState
+from .sources.de import DataExplorerFetcher
 from .sources.di import DatasetIncubatorFetcher
 from .sources.so import SourceObservatoryFetcher
 from .signals import (
+    ExplorerTheme,
     RadarSummary,
     SourceObservatorySignals,
 )
@@ -44,6 +46,7 @@ class Renderer:
         self.fixed_timestamp = fixed_timestamp or datetime.now().isoformat()
         self._so_fetcher = SourceObservatoryFetcher(self.github_collector)
         self._di_fetcher = DatasetIncubatorFetcher(self.github_collector)
+        self._de_fetcher = DataExplorerFetcher(self.github_collector)
 
     def render_session_bootstrap(self) -> str:
         """Render session_bootstrap.md.
@@ -137,6 +140,39 @@ class Renderer:
             lines.append("**Dataset Catalog**: unavailable")
         lines.append("")
 
+        # ── EXPLORER ──────────────────────────────────────────────────────
+        explorer_themes = self._fetch_explorer_themes()
+        if explorer_themes is not None:
+            lines.append("## 🗂 EXPLORER")
+            lines.append("")
+
+            # Count themed datasets
+            themed_slugs: set[str] = set()
+            for t in explorer_themes:
+                themed_slugs.update(t.datasets)
+
+            # Gap analysis
+            catalog = self._fetch_di_clean_catalog()
+            clean_ready_slugs: set[str] = set()
+            if catalog is not None:
+                for ds in catalog.clean_ready:
+                    clean_ready_slugs.add(ds.slug)
+            gap = sorted(clean_ready_slugs - themed_slugs)
+
+            lines.append(
+                f"**Pubblicati**: {len(themed_slugs)} dataset · "
+                f"{len(explorer_themes)} temi"
+            )
+            for t in explorer_themes:
+                lines.append(f"  · **{t.name}**: {len(t.datasets)} dataset")
+            if gap:
+                lines.append(f"  ⚠ {len(gap)} dataset clean_ready non ancora su explorer:")
+                for slug in gap[:5]:
+                    lines.append(f"    · {slug}")
+                if len(gap) > 5:
+                    lines.append(f"    · ... e altri {len(gap) - 5}")
+            lines.append("")
+
         # ── OPEN ─────────────────────────────────────────────────────────
         prs = self.github_collector.get_prs(self.config.repos)
         github_errors = self.github_collector.fetch_errors
@@ -225,9 +261,13 @@ class Renderer:
             self.fixed_timestamp,
             so_fetcher=self._so_fetcher,
             di_fetcher=self._di_fetcher,
+            de_fetcher=self._de_fetcher,
         )
 
 
+
+    def _fetch_explorer_themes(self) -> list[ExplorerTheme] | None:
+        return self._de_fetcher.fetch_themes()
 
     def _fetch_di_pipeline_signals(self) -> RepoSignals | None:
         return self._di_fetcher.fetch_pipeline_signals()
@@ -329,6 +369,19 @@ class Renderer:
                 "next": topic.next,
             }
 
+        # Explorer themes from data-explorer
+        explorer_themes_list: list[dict[str, Any]] = []
+        explorer_themes = self._fetch_explorer_themes()
+        if explorer_themes is not None:
+            explorer_themes_list = [
+                {
+                    "slug": t.slug,
+                    "name": t.name,
+                    "datasets": t.datasets,
+                }
+                for t in explorer_themes
+            ]
+
         return {
             "schema_version": 2,
             "generated_at": self.fixed_timestamp,
@@ -336,4 +389,5 @@ class Renderer:
             "datasets_by_source": datasets_by_source,
             "candidates_by_source": candidates_by_source,
             "operational_topics": operational_topics,
+            "explorer_themes": explorer_themes_list,
         }

--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -320,6 +320,45 @@ class RadarSummary:
         return [s for s in self.sources if s.status in ("YELLOW", "RED")]
 
 
+@dataclass
+class ExplorerTheme:
+    """Single theme entry from data-explorer catalog/themes.json."""
+
+    slug: str
+    name: str
+    datasets: list[str]
+
+
+def parse_explorer_themes(raw: str) -> list[ExplorerTheme]:
+    """Parse data-explorer catalog/themes.json into ExplorerTheme instances.
+
+    Args:
+        raw: Raw JSON content of themes.json
+
+    Returns:
+        List of ExplorerTheme instances
+
+    Raises:
+        ValueError: If the JSON is invalid
+    """
+    try:
+        data: list[dict[str, Any]] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON: {exc}") from exc
+
+    if not isinstance(data, list):
+        raise ValueError("Expected JSON array at root")
+
+    return [
+        ExplorerTheme(
+            slug=item.get("slug", ""),
+            name=item.get("name", ""),
+            datasets=item.get("datasets", []),
+        )
+        for item in data
+    ]
+
+
 def parse_radar_summary(raw: str) -> RadarSummary:
     try:
         data: dict[str, Any] = json.loads(raw)

--- a/src/agent_context_builder/sources/de.py
+++ b/src/agent_context_builder/sources/de.py
@@ -1,0 +1,57 @@
+"""Data-explorer fetch and parse helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..github import GitHubCollector
+from ..signals import ExplorerTheme, parse_explorer_themes
+
+
+@dataclass
+class DataExplorerData:
+    """Cached data-explorer artifact bundle."""
+
+    themes: list[ExplorerTheme] | None
+
+
+class DataExplorerFetcher:
+    """Fetch data-explorer artifacts from GitHub raw URLs.
+
+    Consumes:
+      - catalog/themes.json (editorial theme assignments)
+    """
+
+    def __init__(self, collector: GitHubCollector):
+        self.collector = collector
+        self._themes_cache: list[ExplorerTheme] | None | object = _UNSET
+
+    def fetch(self) -> DataExplorerData:
+        """Fetch all data-explorer artifacts."""
+        return DataExplorerData(themes=self.fetch_themes())
+
+    def fetch_themes(self) -> list[ExplorerTheme] | None:
+        """Fetch and parse catalog/themes.json from data-explorer.
+
+        Returns None if the artifact is unavailable or malformed.
+        """
+        if self._themes_cache is not _UNSET:
+            return self._themes_cache  # type: ignore[return-value]
+        raw = self.collector.get_raw_file("data-explorer", "catalog/themes.json")
+        if raw is None:
+            self._themes_cache = None
+            return None
+        try:
+            result = parse_explorer_themes(raw)
+        except ValueError as exc:
+            self.collector.fetch_errors["data-explorer:themes"] = str(exc)
+            result = None
+        self._themes_cache = result
+        return result
+
+
+class _Unset:
+    pass
+
+
+_UNSET = _Unset()

--- a/src/agent_context_builder/sources/de.py
+++ b/src/agent_context_builder/sources/de.py
@@ -64,7 +64,7 @@ class DataExplorerFetcher:
         """
         if self._deploy_cache is not _UNSET:
             return self._deploy_cache  # type: ignore[return-value]
-        result = self.collector.get_latest_workflow_run("data-explorer")
+        result = self.collector.get_latest_workflow_run("data-explorer", workflow_id="deploy.yml")
         self._deploy_cache = result
         return result
 

--- a/src/agent_context_builder/sources/de.py
+++ b/src/agent_context_builder/sources/de.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from ..github import GitHubCollector
 from ..signals import ExplorerTheme, parse_explorer_themes
@@ -13,22 +14,28 @@ class DataExplorerData:
     """Cached data-explorer artifact bundle."""
 
     themes: list[ExplorerTheme] | None
+    last_deploy: dict[str, Any] | None
 
 
 class DataExplorerFetcher:
-    """Fetch data-explorer artifacts from GitHub raw URLs.
+    """Fetch data-explorer artifacts from GitHub raw URLs + API.
 
     Consumes:
       - catalog/themes.json (editorial theme assignments)
+      - GitHub Actions API (deploy status, operativo)
     """
 
     def __init__(self, collector: GitHubCollector):
         self.collector = collector
         self._themes_cache: list[ExplorerTheme] | None | object = _UNSET
+        self._deploy_cache: dict[str, Any] | None | object = _UNSET
 
     def fetch(self) -> DataExplorerData:
         """Fetch all data-explorer artifacts."""
-        return DataExplorerData(themes=self.fetch_themes())
+        return DataExplorerData(
+            themes=self.fetch_themes(),
+            last_deploy=self.fetch_deploy_status(),
+        )
 
     def fetch_themes(self) -> list[ExplorerTheme] | None:
         """Fetch and parse catalog/themes.json from data-explorer.
@@ -47,6 +54,18 @@ class DataExplorerFetcher:
             self.collector.fetch_errors["data-explorer:themes"] = str(exc)
             result = None
         self._themes_cache = result
+        return result
+
+    def fetch_deploy_status(self) -> dict[str, Any] | None:
+        """Fetch latest deploy workflow run for data-explorer.
+
+        Returns a dict with run_id, name, status, conclusion, started_at,
+        completed_at, html_url — or None if unavailable.
+        """
+        if self._deploy_cache is not _UNSET:
+            return self._deploy_cache  # type: ignore[return-value]
+        result = self.collector.get_latest_workflow_run("data-explorer")
+        self._deploy_cache = result
         return result
 
 

--- a/src/agent_context_builder/triage.py
+++ b/src/agent_context_builder/triage.py
@@ -232,6 +232,7 @@ def _build_explorer_dict(
 
     Cross-references data-explorer themes.json with DI clean_catalog.json
     to surface gap analysis (clean_ready datasets not yet on explorer).
+    Includes last deploy status from GitHub Actions API.
     """
     themes = de_fetcher.fetch_themes()
     if themes is None:
@@ -251,6 +252,19 @@ def _build_explorer_dict(
 
     clean_ready_not_published = sorted(clean_ready_slugs - themed_slugs)
 
+    # Deploy status (operativo — GitHub Actions API)
+    deploy: dict[str, Any] | None = None
+    raw_deploy = de_fetcher.fetch_deploy_status()
+    if raw_deploy is not None:
+        deploy = {
+            "run_id": raw_deploy.get("run_id"),
+            "name": raw_deploy.get("name", ""),
+            "status": raw_deploy.get("status", ""),
+            "conclusion": raw_deploy.get("conclusion"),
+            "completed_at": raw_deploy.get("completed_at", ""),
+            "html_url": raw_deploy.get("html_url", ""),
+        }
+
     return {
         "available": True,
         "themes": [
@@ -259,6 +273,7 @@ def _build_explorer_dict(
         ],
         "published_count": len(themed_slugs),
         "clean_ready_not_published": clean_ready_not_published,
+        "last_deploy": deploy,
     }
 
 

--- a/src/agent_context_builder/triage.py
+++ b/src/agent_context_builder/triage.py
@@ -8,6 +8,7 @@ from .config import Config
 from .discussions import Discussion, DiscussionCollector
 from .git_local import GitLocalCollector, GitState
 from .github import GitHubCollector, PR
+from .sources.de import DataExplorerFetcher
 from .sources.di import DatasetIncubatorFetcher
 from .sources.so import SourceObservatoryFetcher
 
@@ -20,6 +21,7 @@ def build_workspace_triage(
     fixed_timestamp: str,
     so_fetcher: SourceObservatoryFetcher | None = None,
     di_fetcher: DatasetIncubatorFetcher | None = None,
+    de_fetcher: DataExplorerFetcher | None = None,
 ) -> dict[str, Any]:
     """Build the workspace_triage.json payload."""
     prs = github_collector.get_prs(config.repos)
@@ -34,6 +36,7 @@ def build_workspace_triage(
 
     so_fetcher = so_fetcher or SourceObservatoryFetcher(github_collector)
     di_fetcher = di_fetcher or DatasetIncubatorFetcher(github_collector)
+    de_fetcher = de_fetcher or DataExplorerFetcher(github_collector)
 
     return {
         "generated_at": fixed_timestamp,
@@ -54,6 +57,7 @@ def build_workspace_triage(
         "source_health": _build_source_health_dict(so_fetcher, github_collector),
         "pipeline_state": _build_pipeline_state_dict(di_fetcher, github_collector),
         "dataset_catalog": _build_dataset_catalog_dict(di_fetcher, github_collector),
+        "explorer": _build_explorer_dict(de_fetcher, di_fetcher),
     }
 
 
@@ -217,6 +221,44 @@ def _build_dataset_catalog_dict(
             }
             for d in catalog.datasets
         ],
+    }
+
+
+def _build_explorer_dict(
+    de_fetcher: DataExplorerFetcher,
+    di_fetcher: DatasetIncubatorFetcher,
+) -> dict[str, Any]:
+    """Build explorer state block for workspace_triage.json.
+
+    Cross-references data-explorer themes.json with DI clean_catalog.json
+    to surface gap analysis (clean_ready datasets not yet on explorer).
+    """
+    themes = de_fetcher.fetch_themes()
+    if themes is None:
+        return {"available": False}
+
+    # Collect all dataset slugs referenced in themes
+    themed_slugs: set[str] = set()
+    for theme in themes:
+        themed_slugs.update(theme.datasets)
+
+    # Gap analysis: clean_ready datasets not in any theme
+    catalog = di_fetcher.fetch_clean_catalog()
+    clean_ready_slugs: set[str] = set()
+    if catalog is not None:
+        for ds in catalog.clean_ready:
+            clean_ready_slugs.add(ds.slug)
+
+    clean_ready_not_published = sorted(clean_ready_slugs - themed_slugs)
+
+    return {
+        "available": True,
+        "themes": [
+            {"slug": t.slug, "name": t.name, "dataset_count": len(t.datasets)}
+            for t in themes
+        ],
+        "published_count": len(themed_slugs),
+        "clean_ready_not_published": clean_ready_not_published,
     }
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -398,13 +398,14 @@ def test_render_signals_cached_across_bootstrap_and_triage():
     renderer.render_session_bootstrap()
     renderer.render_workspace_triage()
 
-    # Four distinct files fetched once each (portal_scout removed — SO no longer produces it)
-    assert gh.get_raw_file.call_count == 4
+    # Five distinct files fetched once each (SO 2 + DI 2 + data-explorer 1)
+    assert gh.get_raw_file.call_count == 5
     paths_fetched = [call.args[1] for call in gh.get_raw_file.call_args_list]
     assert "data/radar/radar_summary.json" in paths_fetched
     assert "data/catalog/catalog_signals.json" in paths_fetched
     assert "registry/pipeline_signals.json" in paths_fetched
     assert "registry/clean_catalog.json" in paths_fetched
+    assert "catalog/themes.json" in paths_fetched
 
 
 def test_render_topic_index():


### PR DESCRIPTION
## Summary

ACB inizia a consumare `catalog/themes.json` da **data-explorer** (contratto già pubblico, zero modifiche all'explorer) e lo integra in tutti e 3 gli artifact prodotti.

### Cosa cambia

**session_bootstrap.md** — nuova sezione `🗂 EXPLORER`:
- Dataset pubblicati per tema
- Gap analysis: clean_ready non ancora su explorer
- Stato ultimo deploy (✅/❌)

**workspace_triage.json** — nuovo campo `explorer`:
- `themes[]`: slug, name, dataset_count
- `published_count`: dataset con tema
- `clean_ready_not_published[]`: gap analysis
- `last_deploy`: run_id, conclusion, completed_at, html_url

**topic_index.json** — nuova sezione `explorer_themes`:
- Array completo slug → name → datasets[]
- Schema version invariato (v2)

**github.py** — nuovo metodo `get_latest_workflow_run()`:
- Generico, riusabile per altri repo
- Graceful degradation: se API fallisce → `None`, nessun blocco

### Contratto formalizzato

`data-explorer/catalog/themes.json` entra nell'artifact registry di ACB come upstream pubblico.

### Test

68/68 passati. Build locale verificato con dati reali.