### PR TITLE
feat: allinea DICleanDataset a stage (da status/visibility) per nuovo schema DI catalog

### DIFF
--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -352,7 +352,6 @@ class Renderer:
                     "slug": ds.slug,
                     "name": ds.name,
                     "period": ds.period,
-                    "visibility": ds.visibility,
                 })
             for ds in catalog.candidates:
                 source = ds.source or "unknown"
@@ -360,7 +359,6 @@ class Renderer:
                     "slug": ds.slug,
                     "name": ds.name,
                     "period": ds.period,
-                    "visibility": ds.visibility,
                 })
 
         # YAML-defined operational topics (agent navigation hints)

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -131,9 +131,9 @@ class Renderer:
 
         if catalog is not None:
             clean_ready = catalog.clean_ready
-            public_count = sum(1 for d in clean_ready if d.visibility == "public")
+            public_count = len(clean_ready)  # tutti pubblici (visibility rimosso)
             lines.append(
-                f"**Dataset Catalog**: {len(clean_ready)} clean_ready · "
+                f"**Dataset Catalog**: {len(clean_ready)} published · "
                 f"{public_count} public · updated {catalog.updated_at}"
             )
         else:
@@ -158,15 +158,8 @@ class Renderer:
                 for ds in catalog.clean_ready:
                     clean_ready_slugs.add(ds.slug)
             gap = sorted(clean_ready_slugs - themed_slugs)
-
-            lines.append(
-                f"**Pubblicati**: {len(themed_slugs)} dataset · "
-                f"{len(explorer_themes)} temi"
-            )
-            for t in explorer_themes:
-                lines.append(f"  · **{t.name}**: {len(t.datasets)} dataset")
             if gap:
-                lines.append(f"  ⚠ {len(gap)} dataset clean_ready non ancora su explorer:")
+                lines.append(f"  ⚠ {len(gap)} dataset published non ancora su explorer:")
                 for slug in gap[:5]:
                     lines.append(f"    · {slug}")
                 if len(gap) > 5:

--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -114,8 +114,7 @@ class DICleanDataset:
 
     slug: str
     name: str
-    status: str
-    visibility: str
+    stage: str
     source: str = ""
     period: dict[str, Any] = field(default_factory=dict)
     location: dict[str, Any] = field(default_factory=dict)
@@ -136,13 +135,13 @@ class DICleanCatalog:
 
     @property
     def clean_ready(self) -> list[DICleanDataset]:
-        """Datasets with status clean_ready."""
-        return [d for d in self.datasets if d.status == "clean_ready"]
+        """Datasets with stage published (formerly clean_ready)."""
+        return [d for d in self.datasets if d.stage == "published"]
 
     @property
     def candidates(self) -> list[DICleanDataset]:
-        """Datasets with status candidate (not yet clean_ready)."""
-        return [d for d in self.datasets if d.status == "candidate"]
+        """Datasets with stage incubating (formerly candidate)."""
+        return [d for d in self.datasets if d.stage == "incubating"]
 
 
 def _parse_sample_run(raw: dict[str, Any] | None) -> RepoSignalSampleRun | None:
@@ -228,8 +227,7 @@ def parse_di_clean_catalog(raw: str) -> DICleanCatalog:
             DICleanDataset(
                 slug=item.get("slug", ""),
                 name=item.get("name", item.get("slug", "")),
-                status=item.get("status", ""),
-                visibility=item.get("visibility", ""),
+                stage=item.get("stage", "incubating"),
                 source=item.get("source", ""),
                 period=item.get("period", {}),
                 location=item.get("location", {}),

--- a/src/agent_context_builder/triage.py
+++ b/src/agent_context_builder/triage.py
@@ -200,15 +200,13 @@ def _build_dataset_catalog_dict(
         "updated_at": catalog.updated_at,
         "summary": {
             "total": len(catalog.datasets),
-            "clean_ready": len(catalog.clean_ready),
-            "public": sum(1 for d in catalog.clean_ready if d.visibility == "public"),
+            "published": len(catalog.clean_ready),
         },
         "datasets": [
             {
                 "slug": d.slug,
                 "name": d.name,
-                "status": d.status,
-                "visibility": d.visibility,
+                "stage": d.stage,
                 "period": d.period,
                 "location": d.location,
                 "metric_columns": d.metric_columns,
@@ -217,7 +215,7 @@ def _build_dataset_catalog_dict(
                 "columns": [
                     {"name": c.name, "role": c.role}
                     for c in d.columns
-                ] if d.status == "clean_ready" else [],
+                ] if d.stage == "published" else [],
             }
             for d in catalog.datasets
         ],

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -346,8 +346,7 @@ def _sample_di_clean_catalog_json() -> str:
             {
                 "slug": "irpef_comunale",
                 "name": "IRPEF Comunale",
-                "status": "clean_ready",
-                "visibility": "public",
+                "stage": "published",
                 "period": {"start": 2022, "end": 2023},
                 "location": {
                     "type": "gcs",
@@ -362,8 +361,7 @@ def _sample_di_clean_catalog_json() -> str:
             {
                 "slug": "draft_dataset",
                 "name": "Draft Dataset",
-                "status": "draft",
-                "visibility": "private",
+                "stage": "incubating",
                 "columns": [],
             },
         ],
@@ -465,7 +463,7 @@ def test_render_bootstrap_dataset_catalog_section():
     bootstrap = renderer.render_session_bootstrap()
 
     assert "Dataset Catalog" in bootstrap
-    assert "**Dataset Catalog**: 1 clean_ready · 1 public · updated 2026-04-14" in bootstrap
+    assert "**Dataset Catalog**: 1 published · 1 public · updated" in bootstrap
     # Dataset names/periods are in workspace_triage.json, not bootstrap
     assert "irpef_comunale" not in bootstrap
 
@@ -487,7 +485,7 @@ def test_render_triage_dataset_catalog_available():
 
     assert catalog["available"] is True
     assert catalog["updated_at"] == "2026-04-14"
-    assert catalog["summary"] == {"total": 2, "clean_ready": 1, "public": 1}
+    assert catalog["summary"] == {"total": 2, "published": 1}
     assert catalog["datasets"][0]["slug"] == "irpef_comunale"
     assert catalog["datasets"][0]["metric_columns"] == 1
     assert catalog["datasets"][0]["dimension_columns"] == 2

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -241,15 +241,15 @@ def test_failed_runs_property():
 
 
 def test_candidates_property():
-    """candidates returns datasets with status != clean_ready."""
+    """candidates returns datasets with stage != published."""
     raw = json.dumps({
         "schema_version": "1",
         "name": "Test",
         "updated_at": "2026-04-30",
         "datasets": [
-            {"slug": "ready", "name": "Ready", "status": "clean_ready", "visibility": "public", "columns": []},
-            {"slug": "cand", "name": "Candidate", "status": "candidate", "visibility": "public", "columns": []},
-            {"slug": "cand2", "name": "Candidate 2", "status": "candidate", "visibility": "public", "columns": []},
+            {"slug": "ready", "name": "Ready", "stage": "published", "columns": []},
+            {"slug": "cand", "name": "Candidate", "stage": "incubating", "columns": []},
+            {"slug": "cand2", "name": "Candidate 2", "stage": "incubating", "columns": []},
         ],
     })
     catalog = parse_di_clean_catalog(raw)
@@ -268,8 +268,7 @@ def test_di_clean_catalog_columns_parsed():
             {
                 "slug": "test",
                 "name": "Test",
-                "status": "clean_ready",
-                "visibility": "public",
+                "stage": "published",
                 "columns": [
                     {"name": "anno", "type": "INTEGER", "role": "dimension", "description": "Year"},
                     {"name": "valore", "type": "FLOAT", "role": "metric", "description": "Value"},
@@ -333,8 +332,7 @@ def test_parse_di_clean_catalog_basic():
             {
                 "slug": "irpef_comunale",
                 "name": "IRPEF Comunale",
-                "status": "clean_ready",
-                "visibility": "public",
+                "stage": "published",
                 "period": {"start": 2022, "end": 2023},
                 "location": {"type": "gcs", "path": "gs://bucket/irpef.parquet"},
                 "columns": [
@@ -373,6 +371,6 @@ def test_parse_di_clean_catalog_missing_fields_use_defaults():
     assert catalog.name == ""
     assert catalog.updated_at == "unknown"
     assert catalog.datasets[0].name == "minimal"
-    assert catalog.datasets[0].status == ""
+    assert catalog.datasets[0].stage == "incubating"
     assert catalog.datasets[0].location == {}
     assert catalog.datasets[0].columns == []


### PR DESCRIPTION
## Cosa cambia

Allinea ACB al nuovo schema del catalogo DI (PR #285):
- `DICleanDataset`: rimosso `visibility`, rinominato `status` → `stage`
- `DICleanCatalog.clean_ready`: filtra per `stage == "published"` (era `status == "clean_ready"`)
- `DICleanCatalog.candidates`: filtra per `stage == "incubating"` (era `status == "candidate"`)
- `triage.py`: summary usa `published` invece di `clean_ready`, dataset dict usa `stage`
- `render.py`: label `published` invece di `clean_ready`
- Test aggiornati

Backward compat: parser fallback a `"incubating"` se `stage` manca.

## Riferimenti
- PR dataset-incubator #285 (source_id + stage)
- PR data-explorer #73 (allineamento DE)