### PR TITLE
feat: source_id in RepoSignal per cross-referenza con SO

### DIFF
--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -68,11 +68,11 @@ class RepoSignal:
     """Single signal entry following the repo-signals standard v1."""
 
     id: str
-    source_id: str = ""
     status: str  # ok | warn | error
     label: str
     detail: str
     action: str
+    source_id: str = ""
     sample_run: RepoSignalSampleRun | None = None
 
 

--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -68,6 +68,7 @@ class RepoSignal:
     """Single signal entry following the repo-signals standard v1."""
 
     id: str
+    source_id: str = ""
     status: str  # ok | warn | error
     label: str
     detail: str
@@ -178,6 +179,7 @@ def parse_repo_signals(raw: str) -> RepoSignals:
     signals = [
         RepoSignal(
             id=s.get("id", ""),
+            source_id=s.get("source_id", ""),
             status=s.get("status", "ok"),
             label=s.get("label", s.get("id", "")),
             detail=s.get("detail", ""),


### PR DESCRIPTION
## Cosa cambia

- Aggiunto `source_id: str = ""` opzionale a `RepoSignal`
- Aggiornato il parser per leggere `source_id` da `pipeline_signals.json`
- Se il segnale non ha `source_id`, default a `""` (backward compat)

### Perché

`pipeline_signals.json` ora include `source_id` per ogni candidato (PR #289).
Con questo campo, ACB può cross-referenziare:
- Segnali pipeline (ok/warn/error) → fonte SO
- Fonte SO (GREEN/YELLOW/RED) → candidati a rischio

## Riferimenti
- PR dataset-incubator #289 (source_id in pipeline_signals)