### PR TITLE
feat: source_id in DICleanDataset

### DIFF
--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -116,6 +116,7 @@ class DICleanDataset:
     slug: str
     name: str
     stage: str
+    source_id: str = ""
     source: str = ""
     period: dict[str, Any] = field(default_factory=dict)
     location: dict[str, Any] = field(default_factory=dict)
@@ -230,6 +231,7 @@ def parse_di_clean_catalog(raw: str) -> DICleanCatalog:
                 slug=item.get("slug", ""),
                 name=item.get("name", item.get("slug", "")),
                 stage=item.get("stage", "incubating"),
+                source_id=item.get("source_id", ""),
                 source=item.get("source", ""),
                 period=item.get("period", {}),
                 location=item.get("location", {}),


### PR DESCRIPTION
## Cosa cambia

- `DICleanDataset`: aggiunto `source_id: str = ""`
- `parse_di_clean_catalog`: legge `source_id` da `clean_catalog.json`

2 righe, 1 commit. Stessa modifica della #38 ma con branch pulito.