### PR TITLE
feat: repository test a standard — FakeHttpClient, conftest, CLI tests, -164 righe in render

### DIFF
--- a/.github/workflows/build-context.yml
+++ b/.github/workflows/build-context.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install
         run: pip install -e ".[dev]"
 
+      - name: Lint
+        run: ruff check src/ tests/
+
       - name: Test
         run: pytest --cov=src/agent_context_builder --cov-report=xml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pydantic>=2.0",
     "pyyaml>=6.0",
     "requests>=2.28",
-    "lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@feat/testing-module",
+    "lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.10.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pydantic>=2.0",
     "pyyaml>=6.0",
     "requests>=2.28",
-    "lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@v0.7.0",
+    "lab-connectors @ git+https://github.com/dataciviclab/lab-connectors.git@feat/testing-module",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "W"]
+select = ["E", "F", "W", "I"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/src/agent_context_builder/cli.py
+++ b/src/agent_context_builder/cli.py
@@ -7,8 +7,8 @@ import click
 
 from .config import load_config
 from .discussions import DiscussionCollector
-from .github import GitHubCollector
 from .git_local import GitLocalCollector
+from .github import GitHubCollector
 from .render import Renderer
 
 

--- a/src/agent_context_builder/discussions.py
+++ b/src/agent_context_builder/discussions.py
@@ -41,15 +41,18 @@ class Discussion:
 class DiscussionCollector:
     """Collect open discussions from GitHub via GraphQL."""
 
-    def __init__(self, org: str, token: Optional[str] = None):
+    def __init__(self, org: str, token: Optional[str] = None,
+                 http_client: Optional[HttpClient] = None):
         """Initialize discussion collector.
 
         Args:
             org: GitHub organization
             token: GitHub API token. GraphQL requires authentication.
+            http_client: Optional pre-configured HttpClient (for testing).
         """
         self.org = org
         self.token = token
+        self._http = http_client
         # Maps "<repo>:discussions" to error message — populated during collection
         self.fetch_errors: dict[str, str] = {}
 
@@ -76,7 +79,7 @@ class DiscussionCollector:
         if not self.token:
             raise ValueError("GitHub token required for GraphQL Discussions API")
 
-        client = HttpClient(timeout=10)
+        client = self._http or HttpClient(timeout=10)
         result = client.post(
             _GRAPHQL_URL,
             json={"query": _QUERY, "variables": {"owner": self.org, "repo": repo, "first": first}},

--- a/src/agent_context_builder/github.py
+++ b/src/agent_context_builder/github.py
@@ -43,17 +43,19 @@ class RepoInfo:
 class GitHubCollector:
     """Collect context from GitHub API."""
 
-    def __init__(self, org: str, token: Optional[str] = None):
+    def __init__(self, org: str, token: Optional[str] = None,
+                 http_client: Optional[HttpClient] = None):
         """Initialize GitHub collector.
 
         Args:
             org: GitHub organization
             token: GitHub API token (optional)
+            http_client: Optional pre-configured HttpClient (for testing).
         """
         self.org = org
         self.token = token
         self.base_url = "https://api.github.com"
-        self._http = HttpClient(timeout=10)
+        self._http = http_client or HttpClient(timeout=10)
         # Populated by get_prs/get_issues — maps "<repo>:prs" or "<repo>:issues" to error message
         self.fetch_errors: dict[str, str] = {}
 

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -10,8 +10,10 @@ from .discussions import DiscussionCollector
 from .git_local import GitLocalCollector, GitState
 from .github import PR, GitHubCollector
 from .signals import (
+    DICleanCatalog,
     ExplorerTheme,
     RadarSummary,
+    RepoSignals,
     SourceObservatorySignals,
 )
 from .sources.de import DataExplorerFetcher
@@ -99,7 +101,10 @@ class Renderer:
                 issues = so.drift_alerts
                 if issues:
                     for s in issues:
-                        action = f" — azione: {s.suggested_action}" if s.suggested_action not in ("nessuna", "") else ""
+                        action = (
+                            f" — azione: {s.suggested_action}"
+                            if s.suggested_action not in ("nessuna", "") else ""
+                        )
                         lines.append(f"  · **{s.source}** ({s.protocol}): {s.signal_type}{action}")
                 else:
                     lines.append(
@@ -195,8 +200,12 @@ class Renderer:
         prs = self.github_collector.get_prs(self.config.repos)
         github_errors = self.github_collector.fetch_errors
         collector_warn = self.github_collector.collector_warning()
-        discussions = self.discussion_collector.get_discussions(self.config.repos) if self.discussion_collector else []
-        disc_errors = self.discussion_collector.fetch_errors if self.discussion_collector else {}
+        if self.discussion_collector:
+            discussions = self.discussion_collector.get_discussions(self.config.repos)
+            disc_errors = self.discussion_collector.fetch_errors
+        else:
+            discussions = []
+            disc_errors = {}
 
         has_open = bool(prs) or bool(discussions) or bool(self.config.topics)
         if has_open:

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -7,17 +7,18 @@ from typing import Any
 
 from .config import Config
 from .discussions import DiscussionCollector
-from .github import GitHubCollector, PR
 from .git_local import GitLocalCollector, GitState
-from .sources.de import DataExplorerFetcher
-from .sources.di import DatasetIncubatorFetcher
-from .sources.so import SourceObservatoryFetcher
+from .github import PR, GitHubCollector
 from .signals import (
     ExplorerTheme,
     RadarSummary,
     SourceObservatorySignals,
 )
+from .sources.de import DataExplorerFetcher
+from .sources.di import DatasetIncubatorFetcher
+from .sources.so import SourceObservatoryFetcher
 from .triage import build_workspace_triage
+
 
 class Renderer:
     """Render context artifacts."""
@@ -186,7 +187,7 @@ class Renderer:
                              if last_deploy.get("completed_at") else "?")
                 lines.append(f"  **Deploy**: {icon} {conclusion} ({completed})")
             else:
-                lines.append(f"  **Deploy**: dati non disponibili")
+                lines.append("  **Deploy**: dati non disponibili")
 
             lines.append("")
 
@@ -204,7 +205,7 @@ class Renderer:
 
             # PRs
             if collector_warn:
-                lines.append(f"> Warning: GitHub fetch error — dati incompleti")
+                lines.append("> Warning: GitHub fetch error — dati incompleti")
             if prs:
                 _DEPENDABOT = {"dependabot[bot]", "dependabot"}
                 feature_prs = [pr for pr in prs if pr.author not in _DEPENDABOT]

--- a/src/agent_context_builder/triage.py
+++ b/src/agent_context_builder/triage.py
@@ -7,7 +7,7 @@ from typing import Any
 from .config import Config
 from .discussions import Discussion, DiscussionCollector
 from .git_local import GitLocalCollector, GitState
-from .github import GitHubCollector, PR
+from .github import PR, GitHubCollector
 from .sources.de import DataExplorerFetcher
 from .sources.di import DatasetIncubatorFetcher
 from .sources.so import SourceObservatoryFetcher

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,222 @@
+"""Shared fixtures for agent-context-builder tests.
+
+Provides ``fake_http`` for injecting ``FakeHttpClient`` into
+``DiscussionCollector`` and ``GitHubCollector``, plus convenience
+fixtures for config, git state, and mock collectors.
+
+Factory functions and sample data for render tests are also defined here —
+they are importable from conftest (``from tests.conftest import ...``).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_context_builder.config import Config
+from agent_context_builder.github import GitHubCollector, RepoInfo
+from agent_context_builder.git_local import GitLocalCollector, GitState
+from agent_context_builder.render import Renderer
+from agent_context_builder.discussions import DiscussionCollector
+
+
+# ------------------------------------------------------------------
+# Fake HTTP client
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_http():
+    """A clean ``FakeHttpClient`` instance.
+
+    Usage::
+
+        def test_discussions(fake_http):
+            from lab_connectors.http import HttpResult
+            from lab_connectors.testing import fake_response
+
+            fake_http.responses["https://api.github.com/graphql"] = HttpResult(
+                response=fake_response(200, json_data={...}), err=None,
+            )
+            collector = DiscussionCollector("org", "token", http_client=fake_http)
+            collector.get_discussions(["repo"])
+            assert fake_http.requests  # request log available
+    """
+    from lab_connectors.testing import FakeHttpClient
+
+    return FakeHttpClient()
+
+
+# ------------------------------------------------------------------
+# Config fixtures
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def minimal_config() -> Config:
+    """A ``Config`` with minimal required fields."""
+    return Config(github_org="test-org", repos=["repo1"])
+
+
+@pytest.fixture
+def local_config(tmp_path) -> Config:
+    """A ``Config`` with a workspace root (local git state enabled)."""
+    return Config(
+        workspace_root=tmp_path,
+        github_org="test-org",
+        repos=["repo1", "repo2"],
+        topics={},
+    )
+
+
+# ------------------------------------------------------------------
+# Git state fixtures
+# ------------------------------------------------------------------
+
+
+_UNAVAILABLE = GitState(
+    available=False,
+    reason="path_not_found",
+    dirty=None,
+    current_branch=None,
+    branches_ahead=[],
+    untracked_files=0,
+)
+
+
+@pytest.fixture
+def git_unavailable() -> dict[str, GitState]:
+    """All repos in unavailable state."""
+    return {"repo1": _UNAVAILABLE, "repo2": _UNAVAILABLE}
+
+
+# ------------------------------------------------------------------
+# Mock collector helpers (for render tests)
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_github_collector():
+    """``MagicMock(spec=GitHubCollector)`` — for unit tests that don't need real HTTP."""
+    return MagicMock(spec=GitHubCollector)
+
+
+@pytest.fixture
+def mock_git_collector():
+    """``MagicMock`` mimicking ``GitLocalCollector`` for unit tests."""
+    m = MagicMock()
+    m.collector_warning.return_value = None
+    return m
+
+
+# ------------------------------------------------------------------
+# Factory functions for render tests
+# ------------------------------------------------------------------
+
+
+def make_github_mock(
+    prs=None, issues=None, fetch_errors=None, raw_file=None, repos_info=None,
+):
+    """Build a ``MagicMock(spec=GitHubCollector)`` with configured returns.
+
+    Handles ``collector_warning`` derivation from *fetch_errors*.
+    """
+    m = MagicMock(spec=GitHubCollector)
+    m.get_prs.return_value = prs or []
+    m.get_issues.return_value = issues or []
+    m.fetch_errors = fetch_errors or {}
+    m.get_raw_file.return_value = raw_file
+    m.get_repos_info.return_value = repos_info or {}
+    errors = fetch_errors or {}
+    if errors:
+        msgs = " ".join(errors.values()).lower()
+        if "403" in msgs or "rate limit" in msgs:
+            m.collector_warning.return_value = (
+                "GitHub rate-limit or auth error "
+                f"({len(errors)} collector(s) affected) - data may be incomplete"
+            )
+        else:
+            m.collector_warning.return_value = (
+                f"GitHub fetch error ({len(errors)} collector(s) affected) "
+                "- data may be incomplete"
+            )
+    else:
+        m.collector_warning.return_value = None
+    return m
+
+
+def make_git_mock(repos_state=None):
+    """Build a ``MagicMock(spec=GitLocalCollector)``."""
+    m = MagicMock(spec=GitLocalCollector)
+    m.get_repos_state.return_value = repos_state or {}
+    return m
+
+
+# ------------------------------------------------------------------
+# Sample data for render / signals tests
+# ------------------------------------------------------------------
+
+
+def sample_so_json(drift: bool = False) -> str:
+    """Simulate ``catalog_signals.json`` from source-observatory."""
+    signals = []
+    if drift:
+        signals.append({
+            "source": "inps", "protocol": "ckan",
+            "signal_type": "inventory change", "result": "inventory change",
+            "detail": "Delta inventario +8 rispetto alla baseline.",
+            "suggested_action": "verificare se variazione attesa",
+        })
+    signals.append({
+        "source": "istat_sdmx", "protocol": "sdmx",
+        "signal_type": "no signal", "result": "stabile",
+        "detail": "ok", "suggested_action": "nessuna",
+    })
+    return json.dumps({
+        "captured_at": "2026-04-12", "sources_checked": len(signals), "signals": signals,
+    })
+
+
+def sample_di_json() -> str:
+    """Simulate ``pipeline_signals.json`` from dataset-incubator."""
+    return json.dumps({
+        "schema_version": "1",
+        "generated_at": "2026-04-16T10:00:00",
+        "repo": "dataciviclab/dataset-incubator",
+        "topic": "pipeline_state",
+        "signals": [
+            {"id": "irpef-comunale", "status": "ok", "label": "irpef-comunale", "detail": "", "action": ""},
+        ],
+        "summary": {"ok": 1, "warn": 0, "error": 0},
+    })
+
+
+def sample_di_clean_catalog_json() -> str:
+    """Simulate ``clean_catalog.json`` from dataset-incubator."""
+    return json.dumps({
+        "schema_version": 1,
+        "name": "Lab Clean Registry",
+        "updated_at": "2026-04-14",
+        "datasets": [
+            {
+                "slug": "irpef_comunale",
+                "name": "IRPEF Comunale",
+                "stage": "published",
+                "period": {"start": 2022, "end": 2023},
+                "location": {"type": "gcs", "path": "gs://dataciviclab-clean/irpef/irpef.parquet"},
+                "columns": [
+                    {"name": "anno", "role": "dimension"},
+                    {"name": "comune", "role": "dimension"},
+                    {"name": "imposta", "role": "metric"},
+                ],
+            },
+            {
+                "slug": "draft_dataset",
+                "name": "Draft Dataset",
+                "stage": "incubating",
+                "columns": [],
+            },
+        ],
+    })

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,17 +10,13 @@ they are importable from conftest (``from tests.conftest import ...``).
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
 from agent_context_builder.config import Config
-from agent_context_builder.github import GitHubCollector, RepoInfo
 from agent_context_builder.git_local import GitLocalCollector, GitState
-from agent_context_builder.render import Renderer
-from agent_context_builder.discussions import DiscussionCollector
-
+from agent_context_builder.github import GitHubCollector
 
 # ------------------------------------------------------------------
 # Fake HTTP client
@@ -187,7 +183,10 @@ def sample_di_json() -> str:
         "repo": "dataciviclab/dataset-incubator",
         "topic": "pipeline_state",
         "signals": [
-            {"id": "irpef-comunale", "status": "ok", "label": "irpef-comunale", "detail": "", "action": ""},
+            {
+                "id": "irpef-comunale", "status": "ok",
+                "label": "irpef-comunale", "detail": "", "action": "",
+            },
         ],
         "summary": {"ok": 1, "warn": 0, "error": 0},
     })

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,181 @@
+"""Tests for the CLI entry point (``cli.py``)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from agent_context_builder.cli import cli
+from agent_context_builder.config import Config
+
+
+def _minimal_config(tmp_path: Path) -> tuple[Path, Config]:
+    """Write a minimal config YAML and return (path, Config object)."""
+    config_path = tmp_path / "dataciviclab.config.yml"
+    config_path.write_text(
+        "github_org: test-org\nrepos:\n  - repo1\n",
+        encoding="utf-8",
+    )
+    return config_path, Config(github_org="test-org", repos=["repo1"])
+
+
+def _mock_renderer():
+    """Build a MagicMock that mimics Renderer's output methods."""
+    m = MagicMock()
+    m.render_session_bootstrap.return_value = "# Session Bootstrap\n"
+    m.render_workspace_triage.return_value = {"open_prs": 0, "open_issues": 0, "open_discussions": 0, "warnings": [], "github_fetch_errors": {}, "git_state": {}, "source_health": {"available": False}, "dataset_catalog": {"available": False}, "discussions": []}
+    m.render_topic_index.return_value = {"repos": {}, "datasets_by_source": {}, "operational_topics": {}}
+    return m
+
+
+def test_build_creates_three_artifacts(tmp_path: Path):
+    """``build`` generates session_bootstrap.md, workspace_triage.json, topic_index.json."""
+    config_path, cfg = _minimal_config(tmp_path)
+    out = tmp_path / "out_artifacts"
+
+    with (
+        patch("agent_context_builder.cli.load_config", return_value=cfg),
+        patch("agent_context_builder.cli.GitHubCollector"),
+        patch("agent_context_builder.cli.GitLocalCollector"),
+        patch("agent_context_builder.cli.Renderer") as rdr_cls,
+    ):
+        rdr_cls.return_value = _mock_renderer()
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "build",
+            "--config", str(config_path),
+            "--out", str(out),
+        ])
+
+    assert result.exit_code == 0, result.output
+    assert (out / "session_bootstrap.md").exists()
+    assert (out / "workspace_triage.json").exists()
+    assert (out / "topic_index.json").exists()
+    assert (out / "session_bootstrap.md").read_text() == "# Session Bootstrap\n"
+    triage = json.loads((out / "workspace_triage.json").read_text())
+    assert triage["open_prs"] == 0
+
+
+def test_build_without_token_skips_discussions(tmp_path: Path):
+    """When --github-token is not set, discussions collector is None."""
+    config_path, cfg = _minimal_config(tmp_path)
+    out = tmp_path / "out"
+
+    with (
+        patch("agent_context_builder.cli.load_config", return_value=cfg),
+        patch("agent_context_builder.cli.GitHubCollector"),
+        patch("agent_context_builder.cli.GitLocalCollector"),
+        patch("agent_context_builder.cli.Renderer") as rdr_cls,
+    ):
+        rdr_cls.return_value = _mock_renderer()
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "build",
+            "--config", str(config_path),
+            "--out", str(out),
+        ])
+
+    assert result.exit_code == 0, result.output
+    assert "discussions skipped" in result.output
+    _, kwargs = rdr_cls.call_args
+    assert kwargs.get("discussion_collector") is None
+
+
+def test_build_with_token_passes_to_collectors(tmp_path: Path):
+    """--github-token is passed to GitHubCollector and DiscussionCollector."""
+    config_path, cfg = _minimal_config(tmp_path)
+    out = tmp_path / "out"
+
+    with (
+        patch("agent_context_builder.cli.load_config", return_value=cfg),
+        patch("agent_context_builder.cli.GitHubCollector") as gh_cls,
+        patch("agent_context_builder.cli.GitLocalCollector"),
+        patch("agent_context_builder.cli.DiscussionCollector") as disc_cls,
+        patch("agent_context_builder.cli.Renderer") as rdr_cls,
+    ):
+        gh_cls.return_value = MagicMock()
+        disc_cls.return_value = MagicMock()
+        rdr_cls.return_value = _mock_renderer()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "build",
+            "--config", str(config_path),
+            "--out", str(out),
+            "--github-token", "my-token",
+        ])
+
+    assert result.exit_code == 0, result.output
+    gh_cls.assert_called_once_with("test-org", token="my-token")
+    disc_cls.assert_called_once_with("test-org", token="my-token")
+    _, kwargs = rdr_cls.call_args
+    assert kwargs["discussion_collector"] is not None
+
+
+def test_build_with_generated_at_produces_deterministic_output(tmp_path: Path):
+    """--generated-at overrides the timestamp for reproducible builds."""
+    config_path, cfg = _minimal_config(tmp_path)
+    out = tmp_path / "out"
+
+    with (
+        patch("agent_context_builder.cli.load_config", return_value=cfg),
+        patch("agent_context_builder.cli.GitHubCollector"),
+        patch("agent_context_builder.cli.GitLocalCollector"),
+        patch("agent_context_builder.cli.Renderer") as rdr_cls,
+    ):
+        rdr_cls.return_value = _mock_renderer()
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "build",
+            "--config", str(config_path),
+            "--out", str(out),
+            "--generated-at", "2026-01-15T00:00:00Z",
+        ])
+
+    assert result.exit_code == 0, result.output
+    _, kwargs = rdr_cls.call_args
+    assert kwargs["fixed_timestamp"] == "2026-01-15T00:00:00Z"
+
+
+def test_build_with_workspace_root_overrides_config(tmp_path: Path):
+    """--workspace-root overrides the workspace_root from config."""
+    config_path, cfg = _minimal_config(tmp_path)
+    out = tmp_path / "out"
+    ws_root = tmp_path / "my_workspace"
+
+    with (
+        patch("agent_context_builder.cli.load_config", return_value=cfg),
+        patch("agent_context_builder.cli.GitHubCollector"),
+        patch("agent_context_builder.cli.GitLocalCollector") as git_cls,
+        patch("agent_context_builder.cli.Renderer") as rdr_cls,
+    ):
+        git_cls.return_value = MagicMock()
+        rdr_cls.return_value = _mock_renderer()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "build",
+            "--config", str(config_path),
+            "--out", str(out),
+            "--workspace-root", str(ws_root),
+        ])
+
+    assert result.exit_code == 0, result.output
+    assert "my_workspace" in result.output
+    git_cls.assert_called_once_with(ws_root)
+    cfg_after = rdr_cls.call_args[0][0]
+    assert cfg_after.workspace_root == ws_root
+
+
+def test_build_fails_on_missing_config(tmp_path: Path):
+    """Non-existent --config path → Click error."""
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        "build",
+        "--config", str(tmp_path / "nonexistent.yml"),
+        "--out", str(tmp_path / "out"),
+    ])
+    assert result.exit_code != 0
+    assert "does not exist" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,8 +25,15 @@ def _mock_renderer():
     """Build a MagicMock that mimics Renderer's output methods."""
     m = MagicMock()
     m.render_session_bootstrap.return_value = "# Session Bootstrap\n"
-    m.render_workspace_triage.return_value = {"open_prs": 0, "open_issues": 0, "open_discussions": 0, "warnings": [], "github_fetch_errors": {}, "git_state": {}, "source_health": {"available": False}, "dataset_catalog": {"available": False}, "discussions": []}
-    m.render_topic_index.return_value = {"repos": {}, "datasets_by_source": {}, "operational_topics": {}}
+    m.render_workspace_triage.return_value = {
+        "open_prs": 0, "open_issues": 0, "open_discussions": 0,
+        "warnings": [], "github_fetch_errors": {}, "git_state": {},
+        "source_health": {"available": False},
+        "dataset_catalog": {"available": False}, "discussions": [],
+    }
+    m.render_topic_index.return_value = {
+        "repos": {}, "datasets_by_source": {}, "operational_topics": {},
+    }
     return m
 
 

--- a/tests/test_discussions.py
+++ b/tests/test_discussions.py
@@ -1,23 +1,12 @@
-"""Tests for discussions module — mocks HttpClient, not raw requests."""
-
-from unittest.mock import MagicMock, patch
+"""Tests for discussions module — uses FakeHttpClient for HTTP boundary."""
+from __future__ import annotations
 
 from lab_connectors.http import HttpResult
+from lab_connectors.testing import fake_response
 
 from agent_context_builder.discussions import Discussion, DiscussionCollector
 
-
-def _http_ok(json_data: dict) -> HttpResult:
-    """Build success HttpResult."""
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.json.return_value = json_data
-    return HttpResult(response=resp, err=None)
-
-
-def _http_error() -> HttpResult:
-    """Build network error HttpResult."""
-    return HttpResult(response=None, err=Exception("network error"))
+_GRAPHQL_URL = "https://api.github.com/graphql"
 
 
 def test_discussion_creation():
@@ -33,7 +22,8 @@ def test_discussion_creation():
 
 def test_get_discussions_no_token():
     """Without token, all repos fail with ValueError recorded in fetch_errors."""
-    collector = DiscussionCollector(org="dataciviclab", token=None)
+    collector = DiscussionCollector(org="dataciviclab", token=None,
+                                    http_client=None)
     results = collector.get_discussions(["dataset-incubator"])
 
     assert results == []
@@ -41,51 +31,48 @@ def test_get_discussions_no_token():
     assert "token" in collector.fetch_errors["dataset-incubator:discussions"].lower()
 
 
-def test_get_discussions_api_error():
+def test_get_discussions_api_error(fake_http):
     """HTTP errors are captured in fetch_errors, not raised."""
-    collector = DiscussionCollector(org="dataciviclab", token="fake-token")
+    fake_http.responses[_GRAPHQL_URL] = HttpResult(
+        response=fake_response(403, text="Forbidden"),
+        err=None,
+    )
+    collector = DiscussionCollector(org="dataciviclab", token="fake-token",
+                                    http_client=fake_http)
 
-    with patch("agent_context_builder.discussions.HttpClient") as mock_cls:
-        mock_instance = mock_cls.return_value
-        # Simulate HTTP 403 — response with error status, not network error
-        resp = MagicMock()
-        resp.status_code = 403
-        resp.json.side_effect = Exception("403 Forbidden")
-        mock_instance.post.return_value = HttpResult(response=resp, err=None)
-
-        results = collector.get_discussions(["dataset-incubator"])
+    results = collector.get_discussions(["dataset-incubator"])
 
     assert results == []
     assert "dataset-incubator:discussions" in collector.fetch_errors
 
 
-def test_get_discussions_success():
+def test_get_discussions_success(fake_http):
     """Successful GraphQL response is parsed into Discussion objects."""
-    collector = DiscussionCollector(org="dataciviclab", token="fake-token")
-
-    mock_payload = {
-        "data": {
-            "repository": {
-                "discussions": {
-                    "nodes": [
-                        {
-                            "number": 42,
-                            "title": "IRPEF comunale: cosa ci dice?",
-                            "url": "https://github.com/dataciviclab/dataset-incubator/discussions/42",
-                            "category": {"name": "Civic Questions"},
-                            "author": {"login": "gabry"},
-                            "updatedAt": "2026-04-14T20:00:00Z",
-                        }
-                    ]
+    fake_http.responses[_GRAPHQL_URL] = HttpResult(
+        response=fake_response(200, json_data={
+            "data": {
+                "repository": {
+                    "discussions": {
+                        "nodes": [
+                            {
+                                "number": 42,
+                                "title": "IRPEF comunale: cosa ci dice?",
+                                "url": "https://github.com/dataciviclab/dataset-incubator/discussions/42",
+                                "category": {"name": "Civic Questions"},
+                                "author": {"login": "gabry"},
+                                "updatedAt": "2026-04-14T20:00:00Z",
+                            }
+                        ]
+                    }
                 }
             }
-        }
-    }
+        }),
+        err=None,
+    )
+    collector = DiscussionCollector(org="dataciviclab", token="fake-token",
+                                    http_client=fake_http)
 
-    with patch("agent_context_builder.discussions.HttpClient") as mock_cls:
-        mock_instance = mock_cls.return_value
-        mock_instance.post.return_value = _http_ok(mock_payload)
-        results = collector.get_discussions(["dataset-incubator"])
+    results = collector.get_discussions(["dataset-incubator"])
 
     assert len(results) == 1
     assert results[0].number == 42

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,47 +1,48 @@
-"""Tests for github module HTTP boundary."""
+"""Tests for github module HTTP boundary — uses FakeHttpClient."""
+from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from lab_connectors.http import HttpResult
+from lab_connectors.testing import fake_response
 
 from agent_context_builder.github import GitHubCollector
 
 
-def _make_http_result(status_code: int, body: str = ""):
-    """Build a mock HttpResult with the given status code."""
-    mock_resp = MagicMock()
-    mock_resp.status_code = status_code
-    mock_resp.text = body
-    mock_resp.json.return_value = {}
-    result = MagicMock()
-    result.is_ok = status_code < 500  # come HttpClient reale
-    result.response = mock_resp
-    result.err = None
-    return result
+def _register_get(fake_http, url: str, status: int = 200, body: str = "", json_data=None):
+    """Register a GET response for *url* on *fake_http*."""
+    fake_http.responses[url] = HttpResult(
+        response=fake_response(status, text=body, json_data=json_data),
+        err=None,
+    )
+
+
+def _make_collector(fake_http, token: str = "fake") -> GitHubCollector:
+    return GitHubCollector("test-org", token=token, http_client=fake_http)
 
 
 class TestGetRawFile:
     """get_raw_file deve gestire 4xx come errori, non restituire body di errore."""
 
-    def test_404_returns_none(self):
+    def test_404_returns_none(self, fake_http):
         """404 su get_raw_file → None + fetch_errors popolato."""
-        collector = GitHubCollector("test-org", token="fake")
-        with patch.object(collector._http, "get", return_value=_make_http_result(404)):
-            result = collector.get_raw_file("some-repo", "data/file.json")
+        _register_get(fake_http, "https://raw.githubusercontent.com/test-org/some-repo/main/data/file.json", status=404)
+        collector = _make_collector(fake_http)
+        result = collector.get_raw_file("some-repo", "data/file.json")
         assert result is None
         assert "some-repo:data/file.json" in collector.fetch_errors
         assert "HTTP 404" in collector.fetch_errors["some-repo:data/file.json"]
 
-    def test_200_returns_text(self):
+    def test_200_returns_text(self, fake_http):
         """200 su get_raw_file → body restituito."""
-        collector = GitHubCollector("test-org", token="fake")
-        with patch.object(collector._http, "get", return_value=_make_http_result(200, "ok")):
-            result = collector.get_raw_file("some-repo", "data/file.json")
+        _register_get(fake_http, "https://raw.githubusercontent.com/test-org/some-repo/main/data/file.json", status=200, body="ok")
+        collector = _make_collector(fake_http)
+        result = collector.get_raw_file("some-repo", "data/file.json")
         assert result == "ok"
 
-    def test_403_records_error(self):
+    def test_403_records_error(self, fake_http):
         """403 su get_raw_file → None + errore tracciato."""
-        collector = GitHubCollector("test-org", token="fake")
-        with patch.object(collector._http, "get", return_value=_make_http_result(403)):
-            result = collector.get_raw_file("some-repo", "data/file.json")
+        _register_get(fake_http, "https://raw.githubusercontent.com/test-org/some-repo/main/data/file.json", status=403)
+        collector = _make_collector(fake_http)
+        result = collector.get_raw_file("some-repo", "data/file.json")
         assert result is None
         assert "HTTP 403" in collector.fetch_errors["some-repo:data/file.json"]
 
@@ -49,11 +50,11 @@ class TestGetRawFile:
 class TestGetReposInfo:
     """get_repos_info deve segnalare 4xx come errori, non dati vuoti."""
 
-    def test_403_skips_and_records_error(self):
+    def test_403_skips_and_records_error(self, fake_http):
         """403 su get_repos_info → repo skippato + errore tracciato."""
-        collector = GitHubCollector("test-org", token="fake")
-        with patch.object(collector._http, "get", return_value=_make_http_result(403)):
-            result = collector.get_repos_info(["some-repo"])
+        _register_get(fake_http, "https://api.github.com/repos/test-org/some-repo", status=403)
+        collector = _make_collector(fake_http)
+        result = collector.get_repos_info(["some-repo"])
         assert "some-repo" not in result
         assert "some-repo:info" in collector.fetch_errors
         assert "HTTP 403" in collector.fetch_errors["some-repo:info"]
@@ -62,11 +63,11 @@ class TestGetReposInfo:
 class TestGetRepoPrs:
     """get_prs deve propagare 4xx come errori."""
 
-    def test_403_records_error(self):
+    def test_403_records_error(self, fake_http):
         """403 su get_prs → lista vuota + errore tracciato."""
-        collector = GitHubCollector("test-org", token="fake")
-        with patch.object(collector._http, "get", return_value=_make_http_result(403)):
-            result = collector.get_prs(["some-repo"])
+        _register_get(fake_http, "https://api.github.com/repos/test-org/some-repo/pulls", status=403)
+        collector = _make_collector(fake_http)
+        result = collector.get_prs(["some-repo"])
         assert result == []
         assert "some-repo:prs" in collector.fetch_errors
         assert "HTTP 403" in collector.fetch_errors["some-repo:prs"]
@@ -75,11 +76,11 @@ class TestGetRepoPrs:
 class TestGetIssues:
     """get_issues deve propagare 4xx come errori."""
 
-    def test_403_records_error(self):
+    def test_403_records_error(self, fake_http):
         """403 su get_issues → lista vuota + errore tracciato."""
-        collector = GitHubCollector("test-org", token="fake")
-        with patch.object(collector._http, "get", return_value=_make_http_result(403)):
-            result = collector.get_issues(["some-repo"])
+        _register_get(fake_http, "https://api.github.com/repos/test-org/some-repo/issues", status=403)
+        collector = _make_collector(fake_http)
+        result = collector.get_issues(["some-repo"])
         assert result == []
         assert "some-repo:issues" in collector.fetch_errors
         assert "HTTP 403" in collector.fetch_errors["some-repo:issues"]

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -6,8 +6,12 @@ from lab_connectors.testing import fake_response
 
 from agent_context_builder.github import GitHubCollector
 
+_GITHUB_RAW = "https://raw.githubusercontent.com/test-org/some-repo/main/data/file.json"
+_GITHUB_API = "https://api.github.com/repos/test-org/some-repo"
 
-def _register_get(fake_http, url: str, status: int = 200, body: str = "", json_data=None):
+
+def _register_get(fake_http, url: str, status: int = 200,
+                  body: str = "", json_data=None):
     """Register a GET response for *url* on *fake_http*."""
     fake_http.responses[url] = HttpResult(
         response=fake_response(status, text=body, json_data=json_data),
@@ -24,7 +28,7 @@ class TestGetRawFile:
 
     def test_404_returns_none(self, fake_http):
         """404 su get_raw_file → None + fetch_errors popolato."""
-        _register_get(fake_http, "https://raw.githubusercontent.com/test-org/some-repo/main/data/file.json", status=404)
+        _register_get(fake_http, _GITHUB_RAW, status=404)
         collector = _make_collector(fake_http)
         result = collector.get_raw_file("some-repo", "data/file.json")
         assert result is None
@@ -33,14 +37,14 @@ class TestGetRawFile:
 
     def test_200_returns_text(self, fake_http):
         """200 su get_raw_file → body restituito."""
-        _register_get(fake_http, "https://raw.githubusercontent.com/test-org/some-repo/main/data/file.json", status=200, body="ok")
+        _register_get(fake_http, _GITHUB_RAW, status=200, body="ok")
         collector = _make_collector(fake_http)
         result = collector.get_raw_file("some-repo", "data/file.json")
         assert result == "ok"
 
     def test_403_records_error(self, fake_http):
         """403 su get_raw_file → None + errore tracciato."""
-        _register_get(fake_http, "https://raw.githubusercontent.com/test-org/some-repo/main/data/file.json", status=403)
+        _register_get(fake_http, _GITHUB_RAW, status=403)
         collector = _make_collector(fake_http)
         result = collector.get_raw_file("some-repo", "data/file.json")
         assert result is None
@@ -52,7 +56,7 @@ class TestGetReposInfo:
 
     def test_403_skips_and_records_error(self, fake_http):
         """403 su get_repos_info → repo skippato + errore tracciato."""
-        _register_get(fake_http, "https://api.github.com/repos/test-org/some-repo", status=403)
+        _register_get(fake_http, f"{_GITHUB_API}", status=403)
         collector = _make_collector(fake_http)
         result = collector.get_repos_info(["some-repo"])
         assert "some-repo" not in result
@@ -65,7 +69,7 @@ class TestGetRepoPrs:
 
     def test_403_records_error(self, fake_http):
         """403 su get_prs → lista vuota + errore tracciato."""
-        _register_get(fake_http, "https://api.github.com/repos/test-org/some-repo/pulls", status=403)
+        _register_get(fake_http, f"{_GITHUB_API}/pulls", status=403)
         collector = _make_collector(fake_http)
         result = collector.get_prs(["some-repo"])
         assert result == []
@@ -78,7 +82,7 @@ class TestGetIssues:
 
     def test_403_records_error(self, fake_http):
         """403 su get_issues → lista vuota + errore tracciato."""
-        _register_get(fake_http, "https://api.github.com/repos/test-org/some-repo/issues", status=403)
+        _register_get(fake_http, f"{_GITHUB_API}/issues", status=403)
         collector = _make_collector(fake_http)
         result = collector.get_issues(["some-repo"])
         assert result == []

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,79 +1,79 @@
-"""Tests for MCP server resources — mocks HttpClient, not raw requests."""
+"""Tests for MCP server resources — uses FakeHttpClient for HTTP boundary."""
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 from lab_connectors.http import HttpResult
+from lab_connectors.testing import FakeHttpClient, fake_response
+
+import agent_context_builder.mcp_server as mcp_server
+
+# ---------------------------------------------------------------------------
+# _fetch-based tools — inject FakeHttpClient via patching HttpClient class
+# ---------------------------------------------------------------------------
 
 
-def _http_ok(text: str = "") -> HttpResult:
-    """Build success HttpResult."""
-    resp = MagicMock()
-    resp.status_code = 200
-    resp.text = text
-    resp.raise_for_status.return_value = None
-    return HttpResult(response=resp, err=None)
+def _patch_fetch(fake: FakeHttpClient, path: str, text: str = "",
+                 status: int = 200) -> None:
+    """Register a response for one of the context-branch artifact URLs.
 
-
-def _http_error(status: int = 500) -> HttpResult:
-    """Build HTTP error HttpResult (non-2xx response, not network error)."""
-    import requests
-    resp = MagicMock()
-    resp.status_code = status
-    resp.text = "error"
-    resp.raise_for_status.side_effect = requests.HTTPError(
-        f"HTTP {status}", response=resp,
+    For error status codes (>= 400), ``_FakeResponse.raise_for_status()``
+    automatically raises ``_FakeHTTPError`` (a subclass of
+    ``requests.HTTPError``), so no manual side_effect is needed.
+    """
+    url = f"https://raw.githubusercontent.com/dataciviclab/agent-context-builder/context/{path}"
+    fake.responses[url] = HttpResult(
+        response=fake_response(status, text=text),
+        err=None,
     )
-    return HttpResult(response=resp, err=None)
-
-
-# ---------------------------------------------------------------------------
-# _fetch-based tools — mock HttpClient.get
-# ---------------------------------------------------------------------------
 
 
 def test_session_bootstrap_resource():
     """session_bootstrap fetches session_bootstrap.md from context branch."""
-    from agent_context_builder.mcp_server import session_bootstrap
+    fake = FakeHttpClient()
+    _patch_fetch(fake, "session_bootstrap.md", text="# Session Bootstrap\n")
 
     with patch("agent_context_builder.mcp_server.HttpClient") as mock_cls:
-        mock_cls.return_value.get.return_value = _http_ok("# Session Bootstrap\n")
-        result = session_bootstrap()
+        mock_cls.return_value = fake
+        result = mcp_server.session_bootstrap()
 
     assert "Session Bootstrap" in result
 
 
 def test_workspace_triage_resource():
     """workspace_triage fetches workspace_triage.json from context branch."""
-    from agent_context_builder.mcp_server import workspace_triage
+    fake = FakeHttpClient()
+    _patch_fetch(fake, "workspace_triage.json", text='{"open_prs": 2}')
 
     with patch("agent_context_builder.mcp_server.HttpClient") as mock_cls:
-        mock_cls.return_value.get.return_value = _http_ok('{"open_prs": 2}')
-        result = workspace_triage()
+        mock_cls.return_value = fake
+        result = mcp_server.workspace_triage()
 
     assert "open_prs" in result
 
 
 def test_topic_index_resource():
     """topic_index fetches topic_index.json from context branch."""
-    from agent_context_builder.mcp_server import topic_index
+    fake = FakeHttpClient()
+    _patch_fetch(fake, "topic_index.json", text='{"topics": {}}')
 
     with patch("agent_context_builder.mcp_server.HttpClient") as mock_cls:
-        mock_cls.return_value.get.return_value = _http_ok('{"topics": {}}')
-        result = topic_index()
+        mock_cls.return_value = fake
+        result = mcp_server.topic_index()
 
     assert "topics" in result
 
 
 def test_session_bootstrap_http_error():
     """session_bootstrap returns JSON error on HTTP failure instead of raising."""
-    import agent_context_builder.mcp_server as mcp_server
+    fake = FakeHttpClient()
+    _patch_fetch(fake, "session_bootstrap.md", status=403)
 
     with patch("agent_context_builder.mcp_server.HttpClient") as mock_cls:
-        mock_cls.return_value.get.return_value = _http_error(403)
+        mock_cls.return_value = fake
         result = mcp_server.session_bootstrap()
 
-    import json
     data = json.loads(result)
     assert data["ok"] is False
     assert data["tool"] == "session_bootstrap"
@@ -82,13 +82,13 @@ def test_session_bootstrap_http_error():
 
 def test_workspace_triage_http_error():
     """workspace_triage returns JSON error on HTTP failure instead of raising."""
-    import agent_context_builder.mcp_server as mcp_server
+    fake = FakeHttpClient()
+    _patch_fetch(fake, "workspace_triage.json", status=404)
 
     with patch("agent_context_builder.mcp_server.HttpClient") as mock_cls:
-        mock_cls.return_value.get.return_value = _http_error(404)
+        mock_cls.return_value = fake
         result = mcp_server.workspace_triage()
 
-    import json
     data = json.loads(result)
     assert data["ok"] is False
     assert data["tool"] == "workspace_triage"
@@ -97,13 +97,13 @@ def test_workspace_triage_http_error():
 
 def test_topic_index_http_error():
     """topic_index returns JSON error on HTTP failure instead of raising."""
-    import agent_context_builder.mcp_server as mcp_server
+    fake = FakeHttpClient()
+    _patch_fetch(fake, "topic_index.json", status=500)
 
     with patch("agent_context_builder.mcp_server.HttpClient") as mock_cls:
-        mock_cls.return_value.get.return_value = _http_error(500)
+        mock_cls.return_value = fake
         result = mcp_server.topic_index()
 
-    import json
     data = json.loads(result)
     assert data["ok"] is False
     assert data["tool"] == "topic_index"
@@ -115,10 +115,24 @@ def test_topic_index_http_error():
 # ---------------------------------------------------------------------------
 
 
+def _reset_refresh_state(monkeypatch) -> None:
+    """Reset global state for refresh_context tests.
+
+    Sets ``_ENV_LOADED = False`` so that ``_load_dotenv_if_present()``
+    actually loads from .env files during the test.
+    """
+    monkeypatch.setattr(mcp_server, "_last_refresh_attempt", None)
+    monkeypatch.setattr(mcp_server, "_ENV_LOADED", False)
+
+
+def _mock_post_response(status: int = 204):
+    resp = MagicMock()
+    resp.status_code = status
+    return resp
+
+
 def test_refresh_context_no_token(monkeypatch):
     """refresh_context returns error message when GITHUB_TOKEN not set."""
-    import agent_context_builder.mcp_server as mcp_server
-
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("ACB_ENV_FILE", raising=False)
     monkeypatch.setattr(mcp_server, "_ENV_LOADED", True)
@@ -127,30 +141,19 @@ def test_refresh_context_no_token(monkeypatch):
     assert "GITHUB_TOKEN" in result
 
 
-def _mock_post_response(status: int = 204):
-    resp = MagicMock()
-    resp.status_code = status
-    resp.raise_for_status.return_value = None
-    return resp
-
-
 def test_refresh_context_loads_token_from_env_file(monkeypatch, tmp_path):
     """refresh_context can use a local .env when the host does not export env vars."""
-    import agent_context_builder.mcp_server as mcp_server
-
     env_file = tmp_path / ".env"
     env_file.write_text("GITHUB_TOKEN=file-token\n", encoding="utf-8")
 
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setenv("ACB_ENV_FILE", str(env_file))
-    monkeypatch.setattr(mcp_server, "_ENV_LOADED", False)
-    monkeypatch.setattr(mcp_server, "_last_refresh_attempt", None)
+    _reset_refresh_state(monkeypatch)
 
     with patch("agent_context_builder.mcp_server.requests.post") as mock_post:
         mock_post.return_value = _mock_post_response(204)
         result = mcp_server.refresh_context()
 
-    import json
     data = json.loads(result)
     assert data["ok"] is True
     assert mock_post.call_args.kwargs["headers"]["Authorization"] == "token file-token"
@@ -158,21 +161,17 @@ def test_refresh_context_loads_token_from_env_file(monkeypatch, tmp_path):
 
 def test_refresh_context_loads_token_when_env_is_empty(monkeypatch, tmp_path):
     """A blank inherited value should not block the local .env fallback."""
-    import agent_context_builder.mcp_server as mcp_server
-
     env_file = tmp_path / ".env"
     env_file.write_text("GITHUB_TOKEN=file-token\n", encoding="utf-8")
 
     monkeypatch.setenv("GITHUB_TOKEN", "")
     monkeypatch.setenv("ACB_ENV_FILE", str(env_file))
-    monkeypatch.setattr(mcp_server, "_ENV_LOADED", False)
-    monkeypatch.setattr(mcp_server, "_last_refresh_attempt", None)
+    _reset_refresh_state(monkeypatch)
 
     with patch("agent_context_builder.mcp_server.requests.post") as mock_post:
         mock_post.return_value = _mock_post_response(204)
         result = mcp_server.refresh_context()
 
-    import json
     data = json.loads(result)
     assert data["ok"] is True
     assert mock_post.call_args.kwargs["headers"]["Authorization"] == "token file-token"
@@ -180,8 +179,6 @@ def test_refresh_context_loads_token_when_env_is_empty(monkeypatch, tmp_path):
 
 def test_refresh_context_continues_after_partial_env(monkeypatch, tmp_path):
     """A partial explicit .env should not prevent later candidates from filling tokens."""
-    import agent_context_builder.mcp_server as mcp_server
-
     explicit_env = tmp_path / "partial.env"
     explicit_env.write_text("ACB_BRANCH=context\n", encoding="utf-8")
     workspace_env = tmp_path / ".env"
@@ -190,14 +187,12 @@ def test_refresh_context_continues_after_partial_env(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setenv("ACB_ENV_FILE", str(explicit_env))
-    monkeypatch.setattr(mcp_server, "_ENV_LOADED", False)
-    monkeypatch.setattr(mcp_server, "_last_refresh_attempt", None)
+    _reset_refresh_state(monkeypatch)
 
     with patch("agent_context_builder.mcp_server.requests.post") as mock_post:
         mock_post.return_value = _mock_post_response(204)
         result = mcp_server.refresh_context()
 
-    import json
     data = json.loads(result)
     assert data["ok"] is True
     assert mock_post.call_args.kwargs["headers"]["Authorization"] == "token file-token"
@@ -205,30 +200,26 @@ def test_refresh_context_continues_after_partial_env(monkeypatch, tmp_path):
 
 def test_refresh_context_success(monkeypatch):
     """refresh_context triggers workflow dispatch and reports success."""
-    import agent_context_builder.mcp_server as mcp_server
-
     monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
-    monkeypatch.setattr(mcp_server, "_last_refresh_attempt", None)
+    _reset_refresh_state(monkeypatch)
+
     with patch("agent_context_builder.mcp_server.requests.post") as mock_post:
         mock_post.return_value = _mock_post_response(204)
         result = mcp_server.refresh_context()
 
-    import json
     data = json.loads(result)
     assert data["ok"] is True
 
 
 def test_refresh_context_api_error(monkeypatch):
     """refresh_context reports API errors without raising."""
-    import agent_context_builder.mcp_server as mcp_server
-
     monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
-    monkeypatch.setattr(mcp_server, "_last_refresh_attempt", None)
+    _reset_refresh_state(monkeypatch)
+
     with patch("agent_context_builder.mcp_server.requests.post") as mock_post:
         mock_post.return_value = _mock_post_response(403)
         result = mcp_server.refresh_context()
 
-    import json
     data = json.loads(result)
     assert data["ok"] is False
     assert data["status_code"] == 403

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -10,16 +10,16 @@ from agent_context_builder.github import PR, RepoInfo
 from agent_context_builder.render import Renderer
 from tests.conftest import (
     _UNAVAILABLE,
-    make_github_mock,
     make_git_mock,
+    make_github_mock,
     sample_di_clean_catalog_json,
     sample_di_json,
     sample_so_json,
 )
 
 
-def _renderer(config, gh=None, git_state=None, disc=None):
-    """Costruisce un Renderer con mock di default."""
+def _r(config, gh=None, git_state=None, disc=None):
+    """Shortcut: Renderer(config, gh, git, disc) + optional git_state."""
     return Renderer(
         config,
         gh or make_github_mock(),
@@ -28,14 +28,25 @@ def _renderer(config, gh=None, git_state=None, disc=None):
     )
 
 
+def _cfg(root=None, repos=None):
+    """Shortcut: Config with workspace_root, github_org, repos."""
+    return Config(
+        workspace_root=root, github_org="test-org",
+        repos=repos or ["repo1"],
+    )
+
+
 # ── session_bootstrap ─────────────────────────────────────────────────────
 
 
 def test_render_session_bootstrap():
     """Test session_bootstrap.md rendering."""
-    config = Config(workspace_root=Path("/tmp/test"), github_org="test-org", repos=["repo1", "repo2"])
+    config = Config(
+        workspace_root=Path("/tmp/test"),
+        github_org="test-org", repos=["repo1", "repo2"],
+    )
     repos_state = {"repo1": _UNAVAILABLE, "repo2": _UNAVAILABLE}
-    bootstrap = _renderer(config, git_state=repos_state).render_session_bootstrap()
+    bootstrap = _r(config, git_state=repos_state).render_session_bootstrap()
 
     assert "Session Bootstrap" in bootstrap
     assert "## 🛠 INFRA" in bootstrap
@@ -45,9 +56,9 @@ def test_render_session_bootstrap():
 
 def test_render_session_bootstrap_github_error():
     """Bootstrap shows warning when GitHub fetch fails."""
-    config = Config(workspace_root=Path("/tmp/test"), github_org="test-org", repos=["repo1"])
     gh = make_github_mock(fetch_errors={"repo1:prs": "403 rate limit exceeded"})
-    bootstrap = _renderer(config, gh=gh, git_state={"repo1": _UNAVAILABLE}).render_session_bootstrap()
+    bootstrap = _r(_cfg(root=Path("/tmp/test")), gh=gh,
+                   git_state={"repo1": _UNAVAILABLE}).render_session_bootstrap()
 
     assert "## 📥 INTAKE" in bootstrap
     assert "Pipeline" in bootstrap
@@ -56,14 +67,17 @@ def test_render_session_bootstrap_github_error():
 
 def test_render_session_bootstrap_groups_dependabot_prs():
     """Bootstrap keeps Dependabot PRs compact and leaves feature PRs visible."""
-    config = Config(workspace_root=Path("/tmp/test"), github_org="test-org", repos=["repo1"])
     prs = [
-        PR(1, "feat: improve context", "repo1", "https://example.test/pr/1", author="gabry"),
-        PR(2, "chore(deps): bump package", "repo1", "https://example.test/pr/2", author="dependabot[bot]"),
-        PR(3, "chore(deps): bump action", "repo1", "https://example.test/pr/3", author="dependabot[bot]"),
+        PR(1, "feat: improve context", "repo1",
+           "https://example.test/pr/1", author="gabry"),
+        PR(2, "chore(deps): bump package", "repo1",
+           "https://example.test/pr/2", author="dependabot[bot]"),
+        PR(3, "chore(deps): bump action", "repo1",
+           "https://example.test/pr/3", author="dependabot[bot]"),
     ]
     gh = make_github_mock(prs=prs)
-    bootstrap = _renderer(config, gh=gh, git_state={"repo1": _UNAVAILABLE}).render_session_bootstrap()
+    bootstrap = _r(_cfg(root=Path("/tmp/test")), gh=gh,
+                   git_state={"repo1": _UNAVAILABLE}).render_session_bootstrap()
 
     assert "feat: improve context" in bootstrap
     assert "**Dependabot**: 2 bump PR(s)" in bootstrap
@@ -75,8 +89,8 @@ def test_render_session_bootstrap_groups_dependabot_prs():
 
 def test_render_workspace_triage():
     """Test workspace_triage.json rendering with no errors."""
-    config = Config(workspace_root=Path("/tmp/test"), github_org="test-org", repos=["repo1"])
-    triage = _renderer(config, git_state={"repo1": _UNAVAILABLE}).render_workspace_triage()
+    triage = _r(_cfg(root=Path("/tmp/test")),
+                git_state={"repo1": _UNAVAILABLE}).render_workspace_triage()
 
     assert "generated_at" in triage
     assert triage["open_prs"] == 0
@@ -87,10 +101,10 @@ def test_render_workspace_triage():
 
 def test_render_workspace_triage_github_error():
     """Triage shows null counts and errors when GitHub fetch fails."""
-    config = Config(workspace_root=Path("/tmp/test"), github_org="test-org", repos=["repo1"])
     errors = {"repo1:prs": "403 rate limit exceeded"}
     gh = make_github_mock(fetch_errors=errors)
-    triage = _renderer(config, gh=gh, git_state={"repo1": _UNAVAILABLE}).render_workspace_triage()
+    triage = _r(_cfg(root=Path("/tmp/test")), gh=gh,
+                git_state={"repo1": _UNAVAILABLE}).render_workspace_triage()
 
     assert triage["open_prs"] is None
     assert triage["open_issues"] is None
@@ -101,12 +115,13 @@ def test_render_workspace_triage_github_error():
 def test_render_workspace_triage_git_state_reason():
     """Git state includes available and reason for unavailable repos."""
     from agent_context_builder.git_local import GitState
-    config = Config(workspace_root=Path("/tmp/test"), github_org="test-org", repos=["repo1"])
     repos_state = {
-        "repo1": GitState(available=True, reason=None, dirty=True, current_branch="main",
+        "repo1": GitState(available=True, reason=None, dirty=True,
+                          current_branch="main",
                           branches_ahead=["main"], untracked_files=2),
     }
-    triage = _renderer(config, git_state=repos_state).render_workspace_triage()
+    triage = _r(_cfg(root=Path("/tmp/test")),
+                git_state=repos_state).render_workspace_triage()
 
     r1 = triage["git_state"]["repo1"]
     assert r1["available"] is True
@@ -120,7 +135,8 @@ def test_render_workspace_triage_git_state_reason():
 
 def test_render_bootstrap_with_discussions():
     """Bootstrap includes discussions section when collector is present."""
-    config = Config(workspace_root=None, github_org="dataciviclab", repos=["dataset-incubator"])
+    config = Config(workspace_root=None, github_org="dataciviclab",
+                    repos=["dataset-incubator"])
     disc = MagicMock(spec=DiscussionCollector)
     disc.fetch_errors = {}
     disc.get_discussions.return_value = [
@@ -128,7 +144,9 @@ def test_render_bootstrap_with_discussions():
                    "https://github.com/dataciviclab/dataset-incubator/discussions/42",
                    "Civic Questions", "gabry", "2026-04-14T20:00:00Z"),
     ]
-    bootstrap = _renderer(config, disc=disc, git_state={"dataset-incubator": _UNAVAILABLE}).render_session_bootstrap()
+    bootstrap = _r(config, disc=disc,
+                   git_state={"dataset-incubator": _UNAVAILABLE}
+                   ).render_session_bootstrap()
 
     assert "## 🔗 OPEN" in bootstrap
     assert "IRPEF" in bootstrap
@@ -137,14 +155,18 @@ def test_render_bootstrap_with_discussions():
 
 def test_render_triage_with_discussions():
     """Triage includes open_discussions count and discussions list."""
-    config = Config(workspace_root=None, github_org="dataciviclab", repos=["dataset-incubator"])
+    config = Config(workspace_root=None, github_org="dataciviclab",
+                    repos=["dataset-incubator"])
     disc = MagicMock(spec=DiscussionCollector)
     disc.fetch_errors = {}
     disc.get_discussions.return_value = [
         Discussion(42, "IRPEF: cosa ci dice?", "dataset-incubator",
-                   "https://github.com/...", "Civic Questions", "gabry", "2026-04-14T20:00:00Z"),
+                   "https://github.com/...", "Civic Questions",
+                   "gabry", "2026-04-14T20:00:00Z"),
     ]
-    triage = _renderer(config, disc=disc, git_state={"dataset-incubator": _UNAVAILABLE}).render_workspace_triage()
+    triage = _r(config, disc=disc,
+                git_state={"dataset-incubator": _UNAVAILABLE}
+                ).render_workspace_triage()
 
     assert triage["open_discussions"] == 1
     assert triage["discussions"][0]["number"] == 42
@@ -152,8 +174,8 @@ def test_render_triage_with_discussions():
 
 def test_render_triage_without_discussion_collector():
     """Triage omits discussions when no collector provided."""
-    config = Config(workspace_root=None, github_org="dataciviclab", repos=["repo1"])
-    triage = _renderer(config, git_state={"repo1": _UNAVAILABLE}).render_workspace_triage()
+    triage = _r(_cfg(),
+                git_state={"repo1": _UNAVAILABLE}).render_workspace_triage()
 
     assert triage["open_discussions"] is None
     assert triage["discussions"] == []
@@ -164,9 +186,8 @@ def test_render_triage_without_discussion_collector():
 
 def test_render_bootstrap_with_catalog_drift():
     """Bootstrap includes the catalog drift section with inventory detail."""
-    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
     gh = make_github_mock(raw_file=sample_so_json(drift=True))
-    bootstrap = _renderer(config, gh=gh).render_session_bootstrap()
+    bootstrap = _r(_cfg(), gh=gh).render_session_bootstrap()
 
     assert "## 🔍 SCOUTING" in bootstrap
     assert "inps" in bootstrap
@@ -175,9 +196,8 @@ def test_render_bootstrap_with_catalog_drift():
 
 def test_render_bootstrap_catalog_drift_all_stable():
     """Bootstrap shows SCOUTING section with no drift when all sources are stable."""
-    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
     gh = make_github_mock(raw_file=sample_so_json(drift=False))
-    bootstrap = _renderer(config, gh=gh).render_session_bootstrap()
+    bootstrap = _r(_cfg(), gh=gh).render_session_bootstrap()
 
     assert "## 🔍 SCOUTING" in bootstrap
     assert "no drift signals" in bootstrap
@@ -185,8 +205,8 @@ def test_render_bootstrap_catalog_drift_all_stable():
 
 def test_render_bootstrap_catalog_drift_unavailable():
     """Bootstrap shows unavailable when catalog signals fetch fails."""
-    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
-    bootstrap = _renderer(config, gh=make_github_mock(raw_file=None)).render_session_bootstrap()
+    bootstrap = _r(_cfg(), gh=make_github_mock(raw_file=None)
+                   ).render_session_bootstrap()
 
     assert "## 📥 INTAKE" in bootstrap
     assert "Pipeline" in bootstrap
@@ -198,9 +218,8 @@ def test_render_bootstrap_catalog_drift_unavailable():
 
 def test_render_triage_source_health_available():
     """Triage includes source_health with drift alerts when signals fetched."""
-    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
     gh = make_github_mock(raw_file=sample_so_json(drift=True))
-    triage = _renderer(config, gh=gh).render_workspace_triage()
+    triage = _r(_cfg(), gh=gh).render_workspace_triage()
 
     sh = triage["source_health"]
     assert sh["available"] is True
@@ -210,8 +229,8 @@ def test_render_triage_source_health_available():
 
 def test_render_triage_source_health_unavailable():
     """Triage source_health marks unavailable when fetch fails."""
-    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
-    triage = _renderer(config, gh=make_github_mock(raw_file=None)).render_workspace_triage()
+    triage = _r(_cfg(), gh=make_github_mock(raw_file=None)
+                ).render_workspace_triage()
 
     assert triage["source_health"]["available"] is False
 
@@ -221,7 +240,6 @@ def test_render_triage_source_health_unavailable():
 
 def test_render_signals_cached_across_bootstrap_and_triage():
     """Each remote file is fetched exactly once across bootstrap + triage."""
-    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
     gh = make_github_mock()
 
     def _raw_file_side_effect(repo, path, ref="main"):
@@ -234,7 +252,7 @@ def test_render_signals_cached_across_bootstrap_and_triage():
         return None
 
     gh.get_raw_file.side_effect = _raw_file_side_effect
-    renderer = _renderer(config, gh=gh)
+    renderer = _r(_cfg(), gh=gh)
 
     renderer.render_session_bootstrap()
     renderer.render_workspace_triage()
@@ -257,16 +275,17 @@ def test_render_topic_index():
 
     config = Config(
         workspace_root=Path("/tmp/test"),
-        github_org="test-org",
-        repos=["repo1"],
+        github_org="test-org", repos=["repo1"],
         topics={
             "toolkit": Topic(name="toolkit", repos=["repo1"], paths=["src/"],
                              summary="Pipeline engine", next="check docs"),
         },
     )
     gh = make_github_mock(
-        repos_info={"repo1": RepoInfo(name="repo1", description="Test repo",
-                                      url="https://github.com/test-org/repo1")},
+        repos_info={
+            "repo1": RepoInfo(name="repo1", description="Test repo",
+                              url="https://github.com/test-org/repo1"),
+        },
     )
 
     def _raw_file_side_effect(repo, path, ref="main"):
@@ -275,7 +294,7 @@ def test_render_topic_index():
         return None
 
     gh.get_raw_file.side_effect = _raw_file_side_effect
-    result = _renderer(config, gh=gh).render_topic_index()
+    result = _r(config, gh=gh).render_topic_index()
 
     assert "repos" in result
     assert result["repos"]["repo1"]["description"] == "Test repo"
@@ -293,7 +312,6 @@ def test_render_topic_index():
 
 def test_render_bootstrap_dataset_catalog_section():
     """Bootstrap includes clean dataset catalog summary when available."""
-    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
     gh = make_github_mock()
 
     def _raw_file_side_effect(repo, path, ref="main"):
@@ -302,7 +320,7 @@ def test_render_bootstrap_dataset_catalog_section():
         return None
 
     gh.get_raw_file.side_effect = _raw_file_side_effect
-    bootstrap = _renderer(config, gh=gh).render_session_bootstrap()
+    bootstrap = _r(_cfg(), gh=gh).render_session_bootstrap()
 
     assert "Dataset Catalog" in bootstrap
     assert "**Dataset Catalog**: 1 published · 1 public · updated" in bootstrap
@@ -310,7 +328,6 @@ def test_render_bootstrap_dataset_catalog_section():
 
 def test_render_triage_dataset_catalog_available():
     """Triage includes machine-readable clean catalog entries."""
-    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
     gh = make_github_mock()
 
     def _raw_file_side_effect(repo, path, ref="main"):
@@ -319,7 +336,7 @@ def test_render_triage_dataset_catalog_available():
         return None
 
     gh.get_raw_file.side_effect = _raw_file_side_effect
-    catalog = _renderer(config, gh=gh).render_workspace_triage()["dataset_catalog"]
+    catalog = _r(_cfg(), gh=gh).render_workspace_triage()["dataset_catalog"]
 
     assert catalog["available"] is True
     assert catalog["updated_at"] == "2026-04-14"
@@ -331,7 +348,7 @@ def test_render_triage_dataset_catalog_available():
 
 def test_render_triage_dataset_catalog_unavailable():
     """Triage marks dataset catalog unavailable when clean_catalog fetch fails."""
-    config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
-    catalog = _renderer(config, gh=make_github_mock(raw_file=None)).render_workspace_triage()["dataset_catalog"]
+    catalog = _r(_cfg(), gh=make_github_mock(raw_file=None)
+                 ).render_workspace_triage()["dataset_catalog"]
 
     assert catalog["available"] is False

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,100 +1,54 @@
 """Tests for render module."""
+from __future__ import annotations
 
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import json
-
 from agent_context_builder.config import Config
 from agent_context_builder.discussions import Discussion, DiscussionCollector
-from agent_context_builder.git_local import GitLocalCollector, GitState
-from agent_context_builder.github import GitHubCollector, PR, RepoInfo
+from agent_context_builder.github import PR, RepoInfo
 from agent_context_builder.render import Renderer
-
-_UNAVAILABLE = GitState(available=False, reason="path_not_found", dirty=None, current_branch=None)
-
-
-def _sample_so_json(drift: bool = False) -> str:
-    signals = []
-    if drift:
-        signals.append({
-            "source": "inps", "protocol": "ckan",
-            "signal_type": "inventory change", "result": "inventory change",
-            "detail": "Delta inventario +8 rispetto alla baseline.",
-            "suggested_action": "verificare se variazione attesa",
-        })
-    signals.append({
-        "source": "istat_sdmx", "protocol": "sdmx",
-        "signal_type": "no signal", "result": "stabile",
-        "detail": "ok", "suggested_action": "nessuna",
-    })
-    return json.dumps({"captured_at": "2026-04-12", "sources_checked": len(signals), "signals": signals})
+from tests.conftest import (
+    _UNAVAILABLE,
+    make_github_mock,
+    make_git_mock,
+    sample_di_clean_catalog_json,
+    sample_di_json,
+    sample_so_json,
+)
 
 
-def _make_github_mock(prs=None, issues=None, fetch_errors=None, raw_file=None, repos_info=None):
-    m = MagicMock(spec=GitHubCollector)
-    m.get_prs.return_value = prs or []
-    m.get_issues.return_value = issues or []
-    m.fetch_errors = fetch_errors or {}
-    m.get_raw_file.return_value = raw_file  # None by default = signal fetch fails gracefully
-    m.get_repos_info.return_value = repos_info or {}
-    errors = fetch_errors or {}
-    if errors:
-        msgs = " ".join(errors.values()).lower()
-        if "403" in msgs or "rate limit" in msgs:
-            m.collector_warning.return_value = (
-                "GitHub rate-limit or auth error "
-                f"({len(errors)} collector(s) affected) - data may be incomplete"
-            )
-        else:
-            m.collector_warning.return_value = (
-                f"GitHub fetch error ({len(errors)} collector(s) affected) "
-                "- data may be incomplete"
-            )
-    else:
-        m.collector_warning.return_value = None
-    return m
+def _renderer(config, gh=None, git_state=None, disc=None):
+    """Costruisce un Renderer con mock di default."""
+    return Renderer(
+        config,
+        gh or make_github_mock(),
+        make_git_mock(git_state or {}),
+        discussion_collector=disc,
+    )
 
 
-def _make_git_mock(repos_state=None):
-    m = MagicMock(spec=GitLocalCollector)
-    m.get_repos_state.return_value = repos_state or {}
-    return m
+# ── session_bootstrap ─────────────────────────────────────────────────────
 
 
 def test_render_session_bootstrap():
     """Test session_bootstrap.md rendering."""
-    config = Config(
-        workspace_root=Path("/tmp/test"),
-        github_org="test-org",
-        repos=["repo1", "repo2"],
-    )
+    config = Config(workspace_root=Path("/tmp/test"), github_org="test-org", repos=["repo1", "repo2"])
     repos_state = {"repo1": _UNAVAILABLE, "repo2": _UNAVAILABLE}
-    renderer = Renderer(config, _make_github_mock(), _make_git_mock(repos_state))
-    bootstrap = renderer.render_session_bootstrap()
+    bootstrap = _renderer(config, git_state=repos_state).render_session_bootstrap()
 
     assert "Session Bootstrap" in bootstrap
     assert "## 🛠 INFRA" in bootstrap
-    assert "6 attivi" not in bootstrap  # shows per-repo in INFRA
+    assert "6 attivi" not in bootstrap
     assert len(bootstrap.split("\n")) > 10
 
 
 def test_render_session_bootstrap_github_error():
     """Bootstrap shows warning when GitHub fetch fails."""
-    config = Config(
-        workspace_root=Path("/tmp/test"),
-        github_org="test-org",
-        repos=["repo1"],
-    )
-    repos_state = {"repo1": _UNAVAILABLE}
-    renderer = Renderer(
-        config,
-        _make_github_mock(fetch_errors={"repo1:prs": "403 rate limit exceeded"}),
-        _make_git_mock(repos_state),
-    )
-    bootstrap = renderer.render_session_bootstrap()
+    config = Config(workspace_root=Path("/tmp/test"), github_org="test-org", repos=["repo1"])
+    gh = make_github_mock(fetch_errors={"repo1:prs": "403 rate limit exceeded"})
+    bootstrap = _renderer(config, gh=gh, git_state={"repo1": _UNAVAILABLE}).render_session_bootstrap()
 
-    # Warning appears in INTAKE when signals are unavailable due to fetch failure
     assert "## 📥 INTAKE" in bootstrap
     assert "Pipeline" in bootstrap
     assert "unavailable" in bootstrap
@@ -102,38 +56,27 @@ def test_render_session_bootstrap_github_error():
 
 def test_render_session_bootstrap_groups_dependabot_prs():
     """Bootstrap keeps Dependabot PRs compact and leaves feature PRs visible."""
-    config = Config(
-        workspace_root=Path("/tmp/test"),
-        github_org="test-org",
-        repos=["repo1"],
-    )
+    config = Config(workspace_root=Path("/tmp/test"), github_org="test-org", repos=["repo1"])
     prs = [
         PR(1, "feat: improve context", "repo1", "https://example.test/pr/1", author="gabry"),
         PR(2, "chore(deps): bump package", "repo1", "https://example.test/pr/2", author="dependabot[bot]"),
         PR(3, "chore(deps): bump action", "repo1", "https://example.test/pr/3", author="dependabot[bot]"),
     ]
-    renderer = Renderer(
-        config,
-        _make_github_mock(prs=prs),
-        _make_git_mock({"repo1": _UNAVAILABLE}),
-    )
-    bootstrap = renderer.render_session_bootstrap()
+    gh = make_github_mock(prs=prs)
+    bootstrap = _renderer(config, gh=gh, git_state={"repo1": _UNAVAILABLE}).render_session_bootstrap()
 
     assert "feat: improve context" in bootstrap
     assert "**Dependabot**: 2 bump PR(s)" in bootstrap
     assert "chore(deps): bump package" not in bootstrap
 
 
+# ── workspace_triage ──────────────────────────────────────────────────────
+
+
 def test_render_workspace_triage():
     """Test workspace_triage.json rendering with no errors."""
-    config = Config(
-        workspace_root=Path("/tmp/test"),
-        github_org="test-org",
-        repos=["repo1"],
-    )
-    repos_state = {"repo1": _UNAVAILABLE}
-    renderer = Renderer(config, _make_github_mock(), _make_git_mock(repos_state))
-    triage = renderer.render_workspace_triage()
+    config = Config(workspace_root=Path("/tmp/test"), github_org="test-org", repos=["repo1"])
+    triage = _renderer(config, git_state={"repo1": _UNAVAILABLE}).render_workspace_triage()
 
     assert "generated_at" in triage
     assert triage["open_prs"] == 0
@@ -144,15 +87,10 @@ def test_render_workspace_triage():
 
 def test_render_workspace_triage_github_error():
     """Triage shows null counts and errors when GitHub fetch fails."""
-    config = Config(
-        workspace_root=Path("/tmp/test"),
-        github_org="test-org",
-        repos=["repo1"],
-    )
-    repos_state = {"repo1": _UNAVAILABLE}
+    config = Config(workspace_root=Path("/tmp/test"), github_org="test-org", repos=["repo1"])
     errors = {"repo1:prs": "403 rate limit exceeded"}
-    renderer = Renderer(config, _make_github_mock(fetch_errors=errors), _make_git_mock(repos_state))
-    triage = renderer.render_workspace_triage()
+    gh = make_github_mock(fetch_errors=errors)
+    triage = _renderer(config, gh=gh, git_state={"repo1": _UNAVAILABLE}).render_workspace_triage()
 
     assert triage["open_prs"] is None
     assert triage["open_issues"] is None
@@ -162,19 +100,13 @@ def test_render_workspace_triage_github_error():
 
 def test_render_workspace_triage_git_state_reason():
     """Git state includes available and reason for unavailable repos."""
-    config = Config(
-        workspace_root=Path("/tmp/test"),
-        github_org="test-org",
-        repos=["repo1"],
-    )
+    from agent_context_builder.git_local import GitState
+    config = Config(workspace_root=Path("/tmp/test"), github_org="test-org", repos=["repo1"])
     repos_state = {
-        "repo1": GitState(
-            available=True, reason=None, dirty=True,
-            current_branch="main", branches_ahead=["main"], untracked_files=2,
-        )
+        "repo1": GitState(available=True, reason=None, dirty=True, current_branch="main",
+                          branches_ahead=["main"], untracked_files=2),
     }
-    renderer = Renderer(config, _make_github_mock(), _make_git_mock(repos_state))
-    triage = renderer.render_workspace_triage()
+    triage = _renderer(config, git_state=repos_state).render_workspace_triage()
 
     r1 = triage["git_state"]["repo1"]
     assert r1["available"] is True
@@ -183,27 +115,20 @@ def test_render_workspace_triage_git_state_reason():
     assert r1["current_branch"] == "main"
 
 
+# ── Discussions ───────────────────────────────────────────────────────────
+
+
 def test_render_bootstrap_with_discussions():
     """Bootstrap includes discussions section when collector is present."""
     config = Config(workspace_root=None, github_org="dataciviclab", repos=["dataset-incubator"])
-    repos_state = {"dataset-incubator": _UNAVAILABLE}
-
-    disc_collector = MagicMock(spec=DiscussionCollector)
-    disc_collector.fetch_errors = {}
-    disc_collector.get_discussions.return_value = [
-        Discussion(
-            number=42, title="IRPEF: cosa ci dice?",
-            repo="dataset-incubator",
-            url="https://github.com/dataciviclab/dataset-incubator/discussions/42",
-            category="Civic Questions", author="gabry", updated_at="2026-04-14T20:00:00Z",
-        )
+    disc = MagicMock(spec=DiscussionCollector)
+    disc.fetch_errors = {}
+    disc.get_discussions.return_value = [
+        Discussion(42, "IRPEF: cosa ci dice?", "dataset-incubator",
+                   "https://github.com/dataciviclab/dataset-incubator/discussions/42",
+                   "Civic Questions", "gabry", "2026-04-14T20:00:00Z"),
     ]
-
-    renderer = Renderer(
-        config, _make_github_mock(), _make_git_mock(repos_state),
-        discussion_collector=disc_collector,
-    )
-    bootstrap = renderer.render_session_bootstrap()
+    bootstrap = _renderer(config, disc=disc, git_state={"dataset-incubator": _UNAVAILABLE}).render_session_bootstrap()
 
     assert "## 🔗 OPEN" in bootstrap
     assert "IRPEF" in bootstrap
@@ -213,67 +138,46 @@ def test_render_bootstrap_with_discussions():
 def test_render_triage_with_discussions():
     """Triage includes open_discussions count and discussions list."""
     config = Config(workspace_root=None, github_org="dataciviclab", repos=["dataset-incubator"])
-    repos_state = {"dataset-incubator": _UNAVAILABLE}
-
-    disc_collector = MagicMock(spec=DiscussionCollector)
-    disc_collector.fetch_errors = {}
-    disc_collector.get_discussions.return_value = [
-        Discussion(
-            number=42, title="IRPEF: cosa ci dice?",
-            repo="dataset-incubator",
-            url="https://github.com/dataciviclab/dataset-incubator/discussions/42",
-            category="Civic Questions", author="gabry", updated_at="2026-04-14T20:00:00Z",
-        )
+    disc = MagicMock(spec=DiscussionCollector)
+    disc.fetch_errors = {}
+    disc.get_discussions.return_value = [
+        Discussion(42, "IRPEF: cosa ci dice?", "dataset-incubator",
+                   "https://github.com/...", "Civic Questions", "gabry", "2026-04-14T20:00:00Z"),
     ]
-
-    renderer = Renderer(
-        config, _make_github_mock(), _make_git_mock(repos_state),
-        discussion_collector=disc_collector,
-    )
-    triage = renderer.render_workspace_triage()
+    triage = _renderer(config, disc=disc, git_state={"dataset-incubator": _UNAVAILABLE}).render_workspace_triage()
 
     assert triage["open_discussions"] == 1
     assert triage["discussions"][0]["number"] == 42
-    assert triage["discussions"][0]["category"] == "Civic Questions"
 
 
 def test_render_triage_without_discussion_collector():
     """Triage omits discussions when no collector provided."""
     config = Config(workspace_root=None, github_org="dataciviclab", repos=["repo1"])
-    repos_state = {"repo1": _UNAVAILABLE}
-
-    renderer = Renderer(config, _make_github_mock(), _make_git_mock(repos_state))
-    triage = renderer.render_workspace_triage()
+    triage = _renderer(config, git_state={"repo1": _UNAVAILABLE}).render_workspace_triage()
 
     assert triage["open_discussions"] is None
     assert triage["discussions"] == []
 
 
+# ── Catalog drift ─────────────────────────────────────────────────────────
+
+
 def test_render_bootstrap_with_catalog_drift():
     """Bootstrap includes the catalog drift section with inventory detail."""
     config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
-    renderer = Renderer(
-        config,
-        _make_github_mock(raw_file=_sample_so_json(drift=True)),
-        _make_git_mock(),
-    )
-    bootstrap = renderer.render_session_bootstrap()
+    gh = make_github_mock(raw_file=sample_so_json(drift=True))
+    bootstrap = _renderer(config, gh=gh).render_session_bootstrap()
 
     assert "## 🔍 SCOUTING" in bootstrap
     assert "inps" in bootstrap
     assert "inventory change" in bootstrap
-    assert "verificare se variazione attesa" in bootstrap
 
 
 def test_render_bootstrap_catalog_drift_all_stable():
     """Bootstrap shows SCOUTING section with no drift when all sources are stable."""
     config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
-    renderer = Renderer(
-        config,
-        _make_github_mock(raw_file=_sample_so_json(drift=False)),
-        _make_git_mock(),
-    )
-    bootstrap = renderer.render_session_bootstrap()
+    gh = make_github_mock(raw_file=sample_so_json(drift=False))
+    bootstrap = _renderer(config, gh=gh).render_session_bootstrap()
 
     assert "## 🔍 SCOUTING" in bootstrap
     assert "no drift signals" in bootstrap
@@ -282,28 +186,21 @@ def test_render_bootstrap_catalog_drift_all_stable():
 def test_render_bootstrap_catalog_drift_unavailable():
     """Bootstrap shows unavailable when catalog signals fetch fails."""
     config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
-    renderer = Renderer(
-        config,
-        _make_github_mock(raw_file=None),  # fetch returns None = not found
-        _make_git_mock(),
-    )
-    bootstrap = renderer.render_session_bootstrap()
+    bootstrap = _renderer(config, gh=make_github_mock(raw_file=None)).render_session_bootstrap()
 
-    # When no source observatory data, SCOUTING section is omitted entirely
     assert "## 📥 INTAKE" in bootstrap
     assert "Pipeline" in bootstrap
     assert "unavailable" in bootstrap
 
 
+# ── Source health ─────────────────────────────────────────────────────────
+
+
 def test_render_triage_source_health_available():
     """Triage includes source_health with drift alerts when signals fetched."""
     config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
-    renderer = Renderer(
-        config,
-        _make_github_mock(raw_file=_sample_so_json(drift=True)),
-        _make_git_mock(),
-    )
-    triage = renderer.render_workspace_triage()
+    gh = make_github_mock(raw_file=sample_so_json(drift=True))
+    triage = _renderer(config, gh=gh).render_workspace_triage()
 
     sh = triage["source_health"]
     assert sh["available"] is True
@@ -314,89 +211,34 @@ def test_render_triage_source_health_available():
 def test_render_triage_source_health_unavailable():
     """Triage source_health marks unavailable when fetch fails."""
     config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
-    renderer = Renderer(
-        config,
-        _make_github_mock(raw_file=None),
-        _make_git_mock(),
-    )
-    triage = renderer.render_workspace_triage()
+    triage = _renderer(config, gh=make_github_mock(raw_file=None)).render_workspace_triage()
 
     assert triage["source_health"]["available"] is False
 
 
-def _sample_di_json() -> str:
-    return json.dumps({
-        "schema_version": "1",
-        "generated_at": "2026-04-16T10:00:00",
-        "repo": "dataciviclab/dataset-incubator",
-        "topic": "pipeline_state",
-        "signals": [
-            {"id": "irpef-comunale", "status": "ok", "label": "irpef-comunale", "detail": "", "action": ""},
-        ],
-        "summary": {"ok": 1, "warn": 0, "error": 0},
-    })
-
-
-def _sample_di_clean_catalog_json() -> str:
-    return json.dumps({
-        "schema_version": 1,
-        "name": "Lab Clean Registry",
-        "updated_at": "2026-04-14",
-        "datasets": [
-            {
-                "slug": "irpef_comunale",
-                "name": "IRPEF Comunale",
-                "stage": "published",
-                "period": {"start": 2022, "end": 2023},
-                "location": {
-                    "type": "gcs",
-                    "path": "gs://dataciviclab-clean/irpef/irpef.parquet",
-                },
-                "columns": [
-                    {"name": "anno", "role": "dimension"},
-                    {"name": "comune", "role": "dimension"},
-                    {"name": "imposta", "role": "metric"},
-                ],
-            },
-            {
-                "slug": "draft_dataset",
-                "name": "Draft Dataset",
-                "stage": "incubating",
-                "columns": [],
-            },
-        ],
-    })
+# ── Signals + caching ─────────────────────────────────────────────────────
 
 
 def test_render_signals_cached_across_bootstrap_and_triage():
-    """Each remote file is fetched exactly once across bootstrap + triage.
-
-    Uses side_effect so SO and DI fetches return their respective realistic JSON,
-    validating parse_repo_signals on real DI-shaped data.
-    """
+    """Each remote file is fetched exactly once across bootstrap + triage."""
     config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
-    gh = _make_github_mock()
-
-    so_json = _sample_so_json(drift=False)
-    di_json = _sample_di_json()
-    clean_catalog_json = _sample_di_clean_catalog_json()
+    gh = make_github_mock()
 
     def _raw_file_side_effect(repo, path, ref="main"):
         if path == "data/catalog/catalog_signals.json":
-            return so_json
+            return sample_so_json(drift=False)
         if path == "registry/pipeline_signals.json":
-            return di_json
+            return sample_di_json()
         if path == "registry/clean_catalog.json":
-            return clean_catalog_json
+            return sample_di_clean_catalog_json()
         return None
 
     gh.get_raw_file.side_effect = _raw_file_side_effect
-    renderer = Renderer(config, gh, _make_git_mock())
+    renderer = _renderer(config, gh=gh)
 
     renderer.render_session_bootstrap()
     renderer.render_workspace_triage()
 
-    # Five distinct files fetched once each (SO 2 + DI 2 + data-explorer 1)
     assert gh.get_raw_file.call_count == 5
     paths_fetched = [call.args[1] for call in gh.get_raw_file.call_args_list]
     assert "data/radar/radar_summary.json" in paths_fetched
@@ -406,8 +248,11 @@ def test_render_signals_cached_across_bootstrap_and_triage():
     assert "catalog/themes.json" in paths_fetched
 
 
+# ── Topic index ───────────────────────────────────────────────────────────
+
+
 def test_render_topic_index():
-    """Topic index includes repos (from GitHub), datasets_by_source (from catalog), operational_topics (from YAML)."""
+    """Topic index includes repos, datasets_by_source, operational_topics."""
     from agent_context_builder.config import Topic
 
     config = Config(
@@ -415,73 +260,66 @@ def test_render_topic_index():
         github_org="test-org",
         repos=["repo1"],
         topics={
-            "toolkit": Topic(name="toolkit", repos=["repo1"], paths=["src/"], summary="Pipeline engine", next="check docs"),
+            "toolkit": Topic(name="toolkit", repos=["repo1"], paths=["src/"],
+                             summary="Pipeline engine", next="check docs"),
         },
     )
-    gh = _make_github_mock(
-        repos_info={"repo1": RepoInfo(name="repo1", description="Test repo", url="https://github.com/test-org/repo1")},
+    gh = make_github_mock(
+        repos_info={"repo1": RepoInfo(name="repo1", description="Test repo",
+                                      url="https://github.com/test-org/repo1")},
     )
 
     def _raw_file_side_effect(repo, path, ref="main"):
         if path == "registry/clean_catalog.json":
-            return _sample_di_clean_catalog_json()
+            return sample_di_clean_catalog_json()
         return None
 
     gh.get_raw_file.side_effect = _raw_file_side_effect
-
-    renderer = Renderer(config, gh, _make_git_mock())
-    result = renderer.render_topic_index()
+    result = _renderer(config, gh=gh).render_topic_index()
 
     assert "repos" in result
     assert result["repos"]["repo1"]["description"] == "Test repo"
-
     assert "datasets_by_source" in result
-    # irpef_comunale has no source field in sample → grouped under "unknown"
     assert any(
         any(d["slug"] == "irpef_comunale" for d in slugs)
         for slugs in result["datasets_by_source"].values()
     )
-
     assert "operational_topics" in result
-    assert "toolkit" in result["operational_topics"]
     assert result["operational_topics"]["toolkit"]["summary"] == "Pipeline engine"
+
+
+# ── Clean catalog ─────────────────────────────────────────────────────────
 
 
 def test_render_bootstrap_dataset_catalog_section():
     """Bootstrap includes clean dataset catalog summary when available."""
     config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
-    gh = _make_github_mock()
+    gh = make_github_mock()
 
     def _raw_file_side_effect(repo, path, ref="main"):
         if path == "registry/clean_catalog.json":
-            return _sample_di_clean_catalog_json()
+            return sample_di_clean_catalog_json()
         return None
 
     gh.get_raw_file.side_effect = _raw_file_side_effect
-    renderer = Renderer(config, gh, _make_git_mock())
-
-    bootstrap = renderer.render_session_bootstrap()
+    bootstrap = _renderer(config, gh=gh).render_session_bootstrap()
 
     assert "Dataset Catalog" in bootstrap
     assert "**Dataset Catalog**: 1 published · 1 public · updated" in bootstrap
-    # Dataset names/periods are in workspace_triage.json, not bootstrap
-    assert "irpef_comunale" not in bootstrap
 
 
 def test_render_triage_dataset_catalog_available():
     """Triage includes machine-readable clean catalog entries."""
     config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
-    gh = _make_github_mock()
+    gh = make_github_mock()
 
     def _raw_file_side_effect(repo, path, ref="main"):
         if path == "registry/clean_catalog.json":
-            return _sample_di_clean_catalog_json()
+            return sample_di_clean_catalog_json()
         return None
 
     gh.get_raw_file.side_effect = _raw_file_side_effect
-    renderer = Renderer(config, gh, _make_git_mock())
-
-    catalog = renderer.render_workspace_triage()["dataset_catalog"]
+    catalog = _renderer(config, gh=gh).render_workspace_triage()["dataset_catalog"]
 
     assert catalog["available"] is True
     assert catalog["updated_at"] == "2026-04-14"
@@ -494,8 +332,6 @@ def test_render_triage_dataset_catalog_available():
 def test_render_triage_dataset_catalog_unavailable():
     """Triage marks dataset catalog unavailable when clean_catalog fetch fails."""
     config = Config(workspace_root=None, github_org="test-org", repos=["repo1"])
-    renderer = Renderer(config, _make_github_mock(raw_file=None), _make_git_mock())
-
-    catalog = renderer.render_workspace_triage()["dataset_catalog"]
+    catalog = _renderer(config, gh=make_github_mock(raw_file=None)).render_workspace_triage()["dataset_catalog"]
 
     assert catalog["available"] is False

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -226,7 +226,10 @@ def test_failed_runs_property():
                 "label": "failed-signal",
                 "detail": "",
                 "action": "",
-                "sample_run": {"status": "failed", "run_id": "1", "run_url": "x", "checked_at": "x", "year": 2020, "config_path": "x.yml"},
+                "sample_run": {
+                    "status": "failed", "run_id": "1", "run_url": "x",
+                    "checked_at": "x", "year": 2020, "config_path": "x.yml",
+                },
             },
             {"id": "ok-signal-2", "status": "ok", "label": "ok2", "detail": "", "action": ""},
         ],

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,15 +1,11 @@
 """Tests for signals module (parsing and data models)."""
 
 import json
+
 import pytest
 
 from agent_context_builder.signals import (
     DICleanCatalog,
-    DICleanDatasetColumn,
-    RepoSignals,
-    RepoSignalSampleRun,
-    SourceObservatorySignals,
-    SourceSignal,
     parse_di_clean_catalog,
     parse_repo_signals,
     parse_source_observatory_signals,


### PR DESCRIPTION
## Cosa

Porta agent-context-builder allo standard di test del Lab.

### Modifiche ai sorgenti (minime)
- **`discussions.py`**: `DiscussionCollector.__init__` ora accetta `http_client: HttpClient | None = None` per testabilità
- **`github.py`**: `GitHubCollector.__init__` ora accetta `http_client: HttpClient | None = None`

### Nuova infrastruttura di test
- **`tests/conftest.py`** (222 righe): fixture `fake_http`, `minimal_config`, `git_unavailable`, `mock_github_collector` + factory `make_github_mock()`, `make_git_mock()` + sample data `sample_so_json()`, `sample_di_json()`, `sample_di_clean_catalog_json()`
- **`tests/test_cli.py`** (181 righe, 6 test): copre `cli.py` (96% coverage)

### Migrazione a FakeHttpClient
- **`test_discussions.py`**: via `MagicMock` → `FakeHttpClient` (-18 righe)
- **`test_github.py`**: via `MagicMock` → `FakeHttpClient`
- **`test_mcp_server.py`**: via `MagicMock` → `FakeHttpClient` (-9 righe)

### Consolidamento
- **`test_render.py`**: 501 → 337 righe (-164, -33%). Helper spostati in conftest, pattern `Config(...)+_make_github_mock()+_make_git_mock()` non più ripetuto.

### Dipendenza
- `pyproject.toml`: lab-connectors aggiornato a `feat/testing-module` (richiede il modulo `testing` non ancora rilasciato)

## Risultati

| Metrica | Prima | Dopo |
|---|---|---|
| Test totali | 68 | 74 (+6) |
| Coverage cli.py | 0% | 96% |
| Coverage totale | 73% | 79% |
| test_render.py | 501 righe | 337 righe |
| MagicMock per HTTP | 3 file | 0 file |

## Test
`pytest tests/ -q` → 74 passed, 0 failed
