### PR TITLE
chore: requires-python >= 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Autonomous context generation for agents: compact bootstrap, workspace triage, topic index"
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 authors = [
     {name = "DataCivicLab", email = "dev@dataciviclab.org"}
 ]


### PR DESCRIPTION
- pyproject.toml: `requires-python >= 3.10` → `>= 3.12`
- Allineato a tutti gli altri repo del Lab