### PR TITLE
test: pytest marker su tutti i test + workflow audit CI + pytest-timeout

### DIFF
--- a/.github/scripts/audit_test_markers.py
+++ b/.github/scripts/audit_test_markers.py
@@ -34,10 +34,12 @@ class TestCollector(ast.NodeVisitor):
     """
 
     def __init__(self) -> None:
+        """Initialize collector with empty results and no module-level markers."""
         self.results: list[dict] = []
         self._module_markers: set[str] = set()
 
     def visit_Module(self, node: ast.Module) -> None:
+        """Collect module-level pytestmark, then scan test functions/classes."""
         # Collect module-level pytestmark first
         for stmt in ast.iter_child_nodes(node):
             if isinstance(stmt, ast.Assign):
@@ -64,6 +66,7 @@ class TestCollector(ast.NodeVisitor):
         self.generic_visit(node)
 
     def _visit_test_function(self, node: ast.FunctionDef) -> None:
+        """Extract markers from a single test function (decorator + module-level)."""
         markers: set[str] = set()
         # Inherit module-level markers
         markers.update(self._module_markers)
@@ -82,6 +85,7 @@ class TestCollector(ast.NodeVisitor):
         )
 
     def _get_marker_name(self, node: ast.expr) -> str | None:
+        """Extract Lab marker name from a decorator via ast.unparse + regex."""
         try:
             src = ast.unparse(node)
             m = _MARKER_RE.search(src)
@@ -93,6 +97,7 @@ class TestCollector(ast.NodeVisitor):
 
 
 def collect_tests(tests_dir: Path, file_filter: list[str] | None = None) -> list[dict]:
+    """Collect all test functions from test_*.py files in directory (recursive)."""
     results = []
     pattern = "test_*.py"
     for fpath in sorted(tests_dir.glob(pattern)):
@@ -134,6 +139,7 @@ def collect_tests(tests_dir: Path, file_filter: list[str] | None = None) -> list
 
 
 def main() -> None:
+    """Parse CLI args, run audit, print results."""
     parser = argparse.ArgumentParser(
         description="Audit test markers in any repo's test directory."
     )

--- a/.github/scripts/audit_test_markers.py
+++ b/.github/scripts/audit_test_markers.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Audit test markers — cross-repo.
+
+Usage:
+    python3 _local/scripts/audit_test_markers.py tests/            # audit entire dir
+    python3 _local/scripts/audit_test_markers.py tests/ --diff     # only unmarked (exit 1 if any)
+    python3 _local/scripts/audit_test_markers.py tests/ --json     # machine-readable
+    python3 _local/scripts/audit_test_markers.py tests/ --files f1.py f2.py  # specific files
+
+Exit code:
+    0 = all tests have markers (or --diff not set)
+    1 = at least one test without marker (only with --diff)
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+
+MARKERS = {"contract", "policy", "regression", "adapter", "pure_unit", "smoke"}
+_MARKER_RE = re.compile(r"mark\.(\w+)")
+
+
+class TestCollector(ast.NodeVisitor):
+    """Collect test functions and their markers via AST.
+
+    Detects markers from:
+    - @pytest.mark.xxx decorators on test functions/methods
+    - Module-level ``pytestmark = pytest.mark.xxx`` (applied to all tests in file)
+    """
+
+    def __init__(self) -> None:
+        self.results: list[dict] = []
+        self._module_markers: set[str] = set()
+
+    def visit_Module(self, node: ast.Module) -> None:
+        # Collect module-level pytestmark first
+        for stmt in ast.iter_child_nodes(node):
+            if isinstance(stmt, ast.Assign):
+                for target in stmt.targets:
+                    if isinstance(target, ast.Name) and target.id == "pytestmark":
+                        marker = self._get_marker_name(stmt.value)
+                        if marker:
+                            self._module_markers.add(marker)
+                    # Also handle list: pytestmark = [pytest.mark.contract, pytest.mark.smoke]
+                    elif isinstance(target, ast.Name) and target.id == "pytestmark":
+                        if isinstance(stmt.value, ast.List):
+                            for elt in stmt.value.elts:
+                                m = self._get_marker_name(elt)
+                                if m:
+                                    self._module_markers.add(m)
+
+        for stmt in ast.iter_child_nodes(node):
+            if isinstance(stmt, ast.FunctionDef) and stmt.name.startswith("test_"):
+                self._visit_test_function(stmt)
+            elif isinstance(stmt, ast.ClassDef):
+                for child in ast.iter_child_nodes(stmt):
+                    if isinstance(child, ast.FunctionDef) and child.name.startswith("test_"):
+                        self._visit_test_function(child)
+        self.generic_visit(node)
+
+    def _visit_test_function(self, node: ast.FunctionDef) -> None:
+        markers: set[str] = set()
+        # Inherit module-level markers
+        markers.update(self._module_markers)
+        # Add per-function decorator markers
+        for decorator in reversed(node.decorator_list):
+            marker = self._get_marker_name(decorator)
+            if marker:
+                markers.add(marker)
+        self.results.append(
+            {
+                "test": node.name,
+                "markers": sorted(markers & MARKERS),
+                "missing": sorted(MARKERS - markers),
+                "unmarked": not bool(markers & MARKERS),
+            }
+        )
+
+    def _get_marker_name(self, node: ast.expr) -> str | None:
+        try:
+            src = ast.unparse(node)
+            m = _MARKER_RE.search(src)
+            if m and m.group(1) in MARKERS:
+                return m.group(1)
+        except Exception:
+            pass
+        return None
+
+
+def collect_tests(tests_dir: Path, file_filter: list[str] | None = None) -> list[dict]:
+    results = []
+    pattern = "test_*.py"
+    for fpath in sorted(tests_dir.glob(pattern)):
+        if fpath.name == "conftest.py":
+            continue
+        if file_filter and fpath.name not in file_filter:
+            continue
+        # Also look in subdirectories
+        if not fpath.is_file():
+            continue
+        try:
+            tree = ast.parse(fpath.read_text(), filename=fpath.name)
+        except SyntaxError:
+            continue
+        visitor = TestCollector()
+        visitor.visit(tree)
+        for r in visitor.results:
+            r["file"] = fpath.name
+            results.append(r)
+
+    # Also scan subdirectories (e.g. tests/http/ in lab-connectors)
+    for subdir in sorted(tests_dir.iterdir()):
+        if not subdir.is_dir() or subdir.name.startswith("__") or subdir.name == "__pycache__":
+            continue
+        for fpath in sorted(subdir.glob("test_*.py")):
+            if file_filter and fpath.name not in file_filter:
+                continue
+            try:
+                tree = ast.parse(fpath.read_text(), filename=fpath.name)
+            except SyntaxError:
+                continue
+            visitor = TestCollector()
+            visitor.visit(tree)
+            for r in visitor.results:
+                r["file"] = str(Path(subdir.name) / fpath.name)
+                results.append(r)
+
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Audit test markers in any repo's test directory."
+    )
+    parser.add_argument("tests_dir", type=str, help="Path to tests/ directory")
+    parser.add_argument(
+        "--diff",
+        action="store_true",
+        help="Exit 1 if any test is unmarked (for CI gate)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Machine-readable JSON output",
+    )
+    parser.add_argument(
+        "--files",
+        nargs="*",
+        default=None,
+        help="Check only specific test files (for PR diff checks)",
+    )
+    args = parser.parse_args()
+
+    tests_path = Path(args.tests_dir)
+    if not tests_path.is_dir():
+        print(f"ERROR: directory not found: {tests_path}", file=sys.stderr)
+        sys.exit(2)
+
+    results = collect_tests(tests_path, args.files)
+    unmarked = [r for r in results if r["unmarked"]]
+    marked = [r for r in results if not r["unmarked"]]
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "total": len(results),
+                    "marked": len(marked),
+                    "unmarked": len(unmarked),
+                    "tests": results,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print("=== Test Marker Audit ===")
+        print(f"Tests: {len(results)} | Marked: {len(marked)} | Unmarked: {len(unmarked)}")
+        print()
+        if unmarked:
+            print(f"--- UNMARKED TESTS ({len(unmarked)}) ---")
+            for r in unmarked:
+                print(f"  {r['file']}::{r['test']}")
+            print()
+            print("Suggested markers (pick one per test):")
+            print("  @pytest.mark.contract  — public interface, artifact format, CLI output")
+            print("  @pytest.mark.policy    — Lab rule not derivable from source code")
+            print("  @pytest.mark.regression — documented bug fix (link issue/PR)")
+            print("  @pytest.mark.adapter   — external service adapter logic")
+            print("  @pytest.mark.pure_unit  — pure logic, zero side effects")
+            print("  @pytest.mark.smoke     — golden path end-to-end")
+            print()
+        if not unmarked:
+            print("All tests have markers. OK")
+
+    if args.diff and unmarked:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/test-audit.yml
+++ b/.github/workflows/test-audit.yml
@@ -1,0 +1,38 @@
+name: Test Marker Audit
+
+on:
+  pull_request:
+    paths:
+      - "tests/test_*.py"
+
+jobs:
+  audit-markers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Audit test markers on changed files
+        run: |
+          # List test files changed in PR (vs base branch)
+          changed=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- 'tests/test_*.py' || true)
+
+          if [ -z "$changed" ]; then
+            echo "No test files changed. OK."
+            exit 0
+          fi
+
+          echo "Changed test files:"
+          echo "$changed"
+
+          # Extract just filenames for the audit script
+          files=$(echo "$changed" | xargs -n1 basename | tr '\n' ' ')
+
+          python .github/scripts/audit_test_markers.py tests/ \
+            --diff \
+            --files $files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,14 @@ packages = ["src/agent_context_builder"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v --cov=src/agent_context_builder"
+markers = [
+    "contract: public interface, artifact format, API contract, CLI stable output",
+    "policy: Lab non-obvious rule or cross-component behavior",
+    "regression: documented bug fix (link to issue/PR)",
+    "adapter: adapter to external service (our wrappers, not library internals)",
+    "pure_unit: non-trivial pure logic, zero side effects",
+    "smoke: end-to-end golden path only",
+]
 
 [tool.ruff]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ mcp = [
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
+    "pytest-timeout>=2.3.0",
     "ruff>=0.1",
     "mypy>=1.0",
     "mcp>=1.0",
@@ -54,7 +55,7 @@ packages = ["src/agent_context_builder"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-v --cov=src/agent_context_builder"
+addopts = "-v --cov=src/agent_context_builder --timeout=30"
 markers = [
     "contract: public interface, artifact format, API contract, CLI stable output",
     "policy: Lab non-obvious rule or cross-component behavior",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,10 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
+
+pytestmark = pytest.mark.contract
 
 from agent_context_builder.cli import cli
 from agent_context_builder.config import Config

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,10 +8,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 from click.testing import CliRunner
 
-pytestmark = pytest.mark.contract
-
 from agent_context_builder.cli import cli
 from agent_context_builder.config import Config
+
+pytestmark = pytest.mark.contract
 
 
 def _minimal_config(tmp_path: Path) -> tuple[Path, Config]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.pure_unit
+
 from agent_context_builder.config import Config, Topic, load_config
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,9 +4,9 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.pure_unit
-
 from agent_context_builder.config import Config, Topic, load_config
+
+pytestmark = pytest.mark.pure_unit
 
 
 def test_topic_creation():

--- a/tests/test_discussions.py
+++ b/tests/test_discussions.py
@@ -1,6 +1,7 @@
 """Tests for discussions module — uses FakeHttpClient for HTTP boundary."""
 from __future__ import annotations
 
+import pytest
 from lab_connectors.http import HttpResult
 from lab_connectors.testing import fake_response
 
@@ -9,6 +10,7 @@ from agent_context_builder.discussions import Discussion, DiscussionCollector
 _GRAPHQL_URL = "https://api.github.com/graphql"
 
 
+@pytest.mark.pure_unit
 def test_discussion_creation():
     """Discussion dataclass holds expected fields."""
     d = Discussion(
@@ -20,6 +22,7 @@ def test_discussion_creation():
     assert d.category == "Civic Questions"
 
 
+@pytest.mark.adapter
 def test_get_discussions_no_token():
     """Without token, all repos fail with ValueError recorded in fetch_errors."""
     collector = DiscussionCollector(org="dataciviclab", token=None,
@@ -31,6 +34,7 @@ def test_get_discussions_no_token():
     assert "token" in collector.fetch_errors["dataset-incubator:discussions"].lower()
 
 
+@pytest.mark.adapter
 def test_get_discussions_api_error(fake_http):
     """HTTP errors are captured in fetch_errors, not raised."""
     fake_http.responses[_GRAPHQL_URL] = HttpResult(
@@ -46,6 +50,7 @@ def test_get_discussions_api_error(fake_http):
     assert "dataset-incubator:discussions" in collector.fetch_errors
 
 
+@pytest.mark.adapter
 def test_get_discussions_success(fake_http):
     """Successful GraphQL response is parsed into Discussion objects."""
     fake_http.responses[_GRAPHQL_URL] = HttpResult(

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,8 +1,11 @@
 """Tests for github module HTTP boundary — uses FakeHttpClient."""
 from __future__ import annotations
 
+import pytest
 from lab_connectors.http import HttpResult
 from lab_connectors.testing import fake_response
+
+pytestmark = pytest.mark.adapter
 
 from agent_context_builder.github import GitHubCollector
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -5,9 +5,9 @@ import pytest
 from lab_connectors.http import HttpResult
 from lab_connectors.testing import fake_response
 
-pytestmark = pytest.mark.adapter
-
 from agent_context_builder.github import GitHubCollector
+
+pytestmark = pytest.mark.adapter
 
 _GITHUB_RAW = "https://raw.githubusercontent.com/test-org/some-repo/main/data/file.json"
 _GITHUB_API = "https://api.github.com/repos/test-org/some-repo"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
 from lab_connectors.http import HttpResult
 from lab_connectors.testing import FakeHttpClient, fake_response
 
@@ -29,6 +30,7 @@ def _patch_fetch(fake: FakeHttpClient, path: str, text: str = "",
     )
 
 
+@pytest.mark.contract
 def test_session_bootstrap_resource():
     """session_bootstrap fetches session_bootstrap.md from context branch."""
     fake = FakeHttpClient()
@@ -41,6 +43,7 @@ def test_session_bootstrap_resource():
     assert "Session Bootstrap" in result
 
 
+@pytest.mark.contract
 def test_workspace_triage_resource():
     """workspace_triage fetches workspace_triage.json from context branch."""
     fake = FakeHttpClient()
@@ -53,6 +56,7 @@ def test_workspace_triage_resource():
     assert "open_prs" in result
 
 
+@pytest.mark.contract
 def test_topic_index_resource():
     """topic_index fetches topic_index.json from context branch."""
     fake = FakeHttpClient()
@@ -65,6 +69,7 @@ def test_topic_index_resource():
     assert "topics" in result
 
 
+@pytest.mark.contract
 def test_session_bootstrap_http_error():
     """session_bootstrap returns JSON error on HTTP failure instead of raising."""
     fake = FakeHttpClient()
@@ -80,6 +85,7 @@ def test_session_bootstrap_http_error():
     assert data["status_code"] == 403
 
 
+@pytest.mark.contract
 def test_workspace_triage_http_error():
     """workspace_triage returns JSON error on HTTP failure instead of raising."""
     fake = FakeHttpClient()
@@ -95,6 +101,7 @@ def test_workspace_triage_http_error():
     assert data["status_code"] == 404
 
 
+@pytest.mark.contract
 def test_topic_index_http_error():
     """topic_index returns JSON error on HTTP failure instead of raising."""
     fake = FakeHttpClient()
@@ -131,6 +138,7 @@ def _mock_post_response(status: int = 204):
     return resp
 
 
+@pytest.mark.adapter
 def test_refresh_context_no_token(monkeypatch):
     """refresh_context returns error message when GITHUB_TOKEN not set."""
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
@@ -141,6 +149,7 @@ def test_refresh_context_no_token(monkeypatch):
     assert "GITHUB_TOKEN" in result
 
 
+@pytest.mark.adapter
 def test_refresh_context_loads_token_from_env_file(monkeypatch, tmp_path):
     """refresh_context can use a local .env when the host does not export env vars."""
     env_file = tmp_path / ".env"
@@ -159,6 +168,7 @@ def test_refresh_context_loads_token_from_env_file(monkeypatch, tmp_path):
     assert mock_post.call_args.kwargs["headers"]["Authorization"] == "token file-token"
 
 
+@pytest.mark.adapter
 def test_refresh_context_loads_token_when_env_is_empty(monkeypatch, tmp_path):
     """A blank inherited value should not block the local .env fallback."""
     env_file = tmp_path / ".env"
@@ -177,6 +187,7 @@ def test_refresh_context_loads_token_when_env_is_empty(monkeypatch, tmp_path):
     assert mock_post.call_args.kwargs["headers"]["Authorization"] == "token file-token"
 
 
+@pytest.mark.adapter
 def test_refresh_context_continues_after_partial_env(monkeypatch, tmp_path):
     """A partial explicit .env should not prevent later candidates from filling tokens."""
     explicit_env = tmp_path / "partial.env"
@@ -198,6 +209,7 @@ def test_refresh_context_continues_after_partial_env(monkeypatch, tmp_path):
     assert mock_post.call_args.kwargs["headers"]["Authorization"] == "token file-token"
 
 
+@pytest.mark.adapter
 def test_refresh_context_success(monkeypatch):
     """refresh_context triggers workflow dispatch and reports success."""
     monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
@@ -211,6 +223,7 @@ def test_refresh_context_success(monkeypatch):
     assert data["ok"] is True
 
 
+@pytest.mark.adapter
 def test_refresh_context_api_error(monkeypatch):
     """refresh_context reports API errors without raising."""
     monkeypatch.setenv("GITHUB_TOKEN", "fake-token")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+
 from agent_context_builder.config import Config
 from agent_context_builder.discussions import Discussion, DiscussionCollector
 from agent_context_builder.github import PR, RepoInfo

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
 from agent_context_builder.config import Config
 from agent_context_builder.discussions import Discussion, DiscussionCollector
 from agent_context_builder.github import PR, RepoInfo
@@ -16,6 +17,8 @@ from tests.conftest import (
     sample_di_json,
     sample_so_json,
 )
+
+pytestmark = pytest.mark.contract
 
 
 def _r(config, gh=None, git_state=None, disc=None):

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -37,6 +37,7 @@ def _sample_json(signals: list[dict] | None = None) -> str:
     })
 
 
+@pytest.mark.pure_unit
 def test_parse_returns_correct_counts():
     so = parse_source_observatory_signals(_sample_json())
     assert so.captured_at == "2026-04-12"
@@ -44,11 +45,13 @@ def test_parse_returns_correct_counts():
     assert len(so.signals) == 2
 
 
+@pytest.mark.pure_unit
 def test_regressions_filter():
     so = parse_source_observatory_signals(_sample_json())
     assert len(so.regressions) == 0
 
 
+@pytest.mark.policy
 def test_drift_alerts_excludes_no_signal():
     """drift_alerts excludes stable sources and keeps catalog drift entries."""
     so = parse_source_observatory_signals(_sample_json())
@@ -57,6 +60,7 @@ def test_drift_alerts_excludes_no_signal():
     assert len(so.alerts) == 1
 
 
+@pytest.mark.pure_unit
 def test_all_stable_empty_filters():
     raw = _sample_json([
         {
@@ -74,11 +78,13 @@ def test_all_stable_empty_filters():
     assert so.drift_alerts == []
 
 
+@pytest.mark.pure_unit
 def test_parse_invalid_json_raises():
     with pytest.raises(ValueError, match="Invalid JSON"):
         parse_source_observatory_signals("not json{")
 
 
+@pytest.mark.policy
 def test_parse_missing_fields_uses_defaults():
     raw = json.dumps({"signals": [{"source": "test"}]})
     so = parse_source_observatory_signals(raw)
@@ -86,6 +92,7 @@ def test_parse_missing_fields_uses_defaults():
     assert so.signals[0].result == ""
 
 
+@pytest.mark.contract
 def test_alerts_alias_matches_drift_alerts():
     """Legacy alerts alias now maps to the catalog drift alerts."""
     so = parse_source_observatory_signals(_sample_json())
@@ -127,6 +134,7 @@ def _sample_repo_signals_json(signals: list[dict] | None = None) -> str:
     })
 
 
+@pytest.mark.pure_unit
 def test_parse_repo_signals_basic():
     rs = parse_repo_signals(_sample_repo_signals_json())
     assert rs.repo == "dataciviclab/dataset-incubator"
@@ -135,6 +143,7 @@ def test_parse_repo_signals_basic():
     assert len(rs.signals) == 3
 
 
+@pytest.mark.pure_unit
 def test_parse_repo_signals_actionable():
     rs = parse_repo_signals(_sample_repo_signals_json())
     actionable = rs.actionable
@@ -143,6 +152,7 @@ def test_parse_repo_signals_actionable():
     assert statuses == {"warn", "error"}
 
 
+@pytest.mark.pure_unit
 def test_parse_repo_signals_all_ok():
     raw = _sample_repo_signals_json([
         {"id": "a", "status": "ok", "label": "a", "detail": "", "action": ""},
@@ -151,11 +161,13 @@ def test_parse_repo_signals_all_ok():
     assert rs.actionable == []
 
 
+@pytest.mark.pure_unit
 def test_parse_repo_signals_invalid_json_raises():
     with pytest.raises(ValueError, match="Invalid JSON"):
         parse_repo_signals("not json{")
 
 
+@pytest.mark.policy
 def test_parse_repo_signals_missing_fields_use_defaults():
     raw = json.dumps({"signals": [{"id": "test"}]})
     rs = parse_repo_signals(raw)
@@ -164,6 +176,7 @@ def test_parse_repo_signals_missing_fields_use_defaults():
     assert rs.signals[0].label == "test"
 
 
+@pytest.mark.contract
 def test_parse_repo_signals_sample_run_parsing():
     """sample_run fields are parsed and exposed on RepoSignal."""
     raw = json.dumps({
@@ -198,6 +211,7 @@ def test_parse_repo_signals_sample_run_parsing():
     assert sr.sample_run.year == 2020
 
 
+@pytest.mark.pure_unit
 def test_parse_repo_signals_no_sample_run():
     """Signal without sample_run has None."""
     raw = json.dumps({
@@ -211,6 +225,7 @@ def test_parse_repo_signals_no_sample_run():
     assert rs.signals[0].sample_run is None
 
 
+@pytest.mark.pure_unit
 def test_failed_runs_property():
     """failed_runs returns only signals with a failed sample_run."""
     raw = json.dumps({
@@ -239,6 +254,7 @@ def test_failed_runs_property():
     assert rs.failed_runs[0].id == "failed-signal"
 
 
+@pytest.mark.pure_unit
 def test_candidates_property():
     """candidates returns datasets with stage != published."""
     raw = json.dumps({
@@ -257,6 +273,7 @@ def test_candidates_property():
     assert {d.slug for d in catalog.candidates} == {"cand", "cand2"}
 
 
+@pytest.mark.contract
 def test_di_clean_catalog_columns_parsed():
     """Column name and role are parsed; type and description are excluded."""
     raw = json.dumps({
@@ -284,6 +301,7 @@ def test_di_clean_catalog_columns_parsed():
     assert ds.columns[1].role == "metric"
 
 
+@pytest.mark.contract
 def test_parse_radar_summary():
     from agent_context_builder.signals import parse_radar_summary
 
@@ -322,6 +340,7 @@ def test_parse_radar_summary():
     assert summary.unhealthy[1].red_streak == 2
 
 
+@pytest.mark.contract
 def test_parse_di_clean_catalog_basic():
     raw = json.dumps({
         "schema_version": 1,
@@ -362,6 +381,7 @@ def test_parse_di_clean_catalog_basic():
     assert dataset.columns[2].role == "metric"
 
 
+@pytest.mark.policy
 def test_parse_di_clean_catalog_missing_fields_use_defaults():
     raw = json.dumps({"datasets": [{"slug": "minimal"}]})
 


### PR DESCRIPTION
## Cosa cambia

1. **Marker pytest su 74 test** (prima: 0% compliance)
   - config → `pure_unit`, cli → `contract`, github → `adapter` (module-level)
   - signals/discussions/mcp_server/render → marker per-test
   - Marker custom registrati in `pyproject.toml`

2. **Workflow audit CI** (`test-audit.yml`)
   - Verifica marker su file test_*.py modificati in PR
   - Fallisce se un test nuovo/modificato non ha marker

3. **pytest-timeout** (--timeout=30) globale

## Perché

La test-policy.md richiede marker obbligatori. ACB era l'unico repo a zero marker. Questo PR porta compliance dal 0% al 100%.

## Verifica

- `python -m pytest tests/ -q`: 74 passed, 0 warnings
- `python _local/scripts/audit_test_markers.py tests/ --diff`: 0 unmarked

Closes: —