### PR TITLE
fix: ripristina sezione EXPLORER in ACB leggendo themes.json.py da data-explorer

### DIFF
--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import json
 from dataclasses import dataclass, field
 from typing import Any
@@ -324,32 +325,68 @@ class RadarSummary:
 
 @dataclass
 class ExplorerTheme:
-    """Single theme entry from data-explorer catalog/themes.json."""
+    """Single theme entry from data-explorer editorial themes."""
 
     slug: str
     name: str
     datasets: list[str]
 
 
-def parse_explorer_themes(raw: str) -> list[ExplorerTheme]:
-    """Parse data-explorer catalog/themes.json into ExplorerTheme instances.
+def parse_explorer_themes_from_py(raw_py: str) -> list[ExplorerTheme]:
+    """Parse themes list from ``src/data/themes.json.py`` source file.
+
+    Instead of fetching a static JSON (which no longer exists after the
+    Observable Framework migration), this function reads the Python data
+    loader file and extracts the ``themes`` variable via ``ast.parse`` +
+    ``ast.literal_eval``.
+
+    The file ``themes.json.py`` in data-explorer has a stable structure:
+    a top-level ``themes`` variable assigned to a list of dicts with
+    ``slug``, ``name``, ``datasets`` (and optional ``description``,
+    ``questions``) keys.
+
+    Uses full AST parsing rather than naive bracket matching so that
+    brackets in docstrings, imports, or other code before ``themes =``
+    do not cause false positives.
 
     Args:
-        raw: Raw JSON content of themes.json
+        raw_py: Raw content of ``src/data/themes.json.py``
 
     Returns:
         List of ExplorerTheme instances
 
     Raises:
-        ValueError: If the JSON is invalid
+        ValueError: If the ``themes`` variable cannot be found or evaluated
     """
     try:
-        data: list[dict[str, Any]] = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"Invalid JSON: {exc}") from exc
+        tree = ast.parse(raw_py)
+    except SyntaxError as exc:
+        raise ValueError(f"Failed to parse themes.json.py as Python: {exc}") from exc
+
+    themes_value = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "themes":
+                    themes_value = node.value
+                    break
+        if themes_value is not None:
+            break
+
+    if themes_value is None:
+        raise ValueError(
+            "No top-level 'themes' variable found in themes.json.py"
+        )
+
+    try:
+        data: list[dict[str, Any]] = ast.literal_eval(themes_value)
+    except (ValueError, SyntaxError) as exc:
+        raise ValueError(f"Failed to evaluate themes literal: {exc}") from exc
 
     if not isinstance(data, list):
-        raise ValueError("Expected JSON array at root")
+        raise ValueError(
+            f"Expected list literal for themes, got {type(data).__name__}"
+        )
 
     return [
         ExplorerTheme(

--- a/src/agent_context_builder/sources/de.py
+++ b/src/agent_context_builder/sources/de.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from ..github import GitHubCollector
-from ..signals import ExplorerTheme, parse_explorer_themes
+from ..signals import ExplorerTheme, parse_explorer_themes_from_py
 
 
 @dataclass
@@ -21,7 +21,7 @@ class DataExplorerFetcher:
     """Fetch data-explorer artifacts from GitHub raw URLs + API.
 
     Consumes:
-      - catalog/themes.json (editorial theme assignments)
+      - src/data/themes.json.py (editorial theme assignments, parsed statically)
       - GitHub Actions API (deploy status, operativo)
     """
 
@@ -38,18 +38,23 @@ class DataExplorerFetcher:
         )
 
     def fetch_themes(self) -> list[ExplorerTheme] | None:
-        """Fetch and parse catalog/themes.json from data-explorer.
+        """Fetch and parse themes from data-explorer's ``themes.json.py``.
 
-        Returns None if the artifact is unavailable or malformed.
+        After the Observable Framework migration, themes no longer live as a
+        static JSON file. They are defined in ``src/data/themes.json.py`` as a
+        Python list literal. This method fetches that source file and extracts
+        the list via static analysis (``ast.literal_eval``).
+
+        Returns None if the file is unavailable or malformed.
         """
         if self._themes_cache is not _UNSET:
             return self._themes_cache  # type: ignore[return-value]
-        raw = self.collector.get_raw_file("data-explorer", "catalog/themes.json")
+        raw = self.collector.get_raw_file("data-explorer", "src/data/themes.json.py")
         if raw is None:
             self._themes_cache = None
             return None
         try:
-            result = parse_explorer_themes(raw)
+            result = parse_explorer_themes_from_py(raw)
         except ValueError as exc:
             self.collector.fetch_errors["data-explorer:themes"] = str(exc)
             result = None

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -267,7 +267,7 @@ def test_render_signals_cached_across_bootstrap_and_triage():
     assert "data/catalog/catalog_signals.json" in paths_fetched
     assert "registry/pipeline_signals.json" in paths_fetched
     assert "registry/clean_catalog.json" in paths_fetched
-    assert "catalog/themes.json" in paths_fetched
+    assert "src/data/themes.json.py" in paths_fetched
 
 
 # ── Topic index ───────────────────────────────────────────────────────────

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -7,6 +7,7 @@ import pytest
 from agent_context_builder.signals import (
     DICleanCatalog,
     parse_di_clean_catalog,
+    parse_explorer_themes_from_py,
     parse_repo_signals,
     parse_source_observatory_signals,
 )
@@ -393,3 +394,155 @@ def test_parse_di_clean_catalog_missing_fields_use_defaults():
     assert catalog.datasets[0].stage == "incubating"
     assert catalog.datasets[0].location == {}
     assert catalog.datasets[0].columns == []
+
+
+# ── parse_explorer_themes_from_py ──────────────────────────────────────────
+
+_THEMES_PY_SAMPLE = '''#!/usr/bin/env python3
+"""Data loader: temi editoriali."""
+import json, sys
+
+themes = [
+    {
+        "slug": "territorio-ambiente",
+        "name": "Territorio e ambiente",
+        "description": "Descrizione",
+        "datasets": ["rifiuti-urbani", "capacita-rinnovabile"],
+        "questions": ["Domanda 1?"],
+    },
+    {
+        "slug": "finanza-pubblica",
+        "name": "Finanza pubblica",
+        "datasets": ["irpef-comunale", "entrate-stato"],
+    },
+]
+json.dump(themes, sys.stdout, ensure_ascii=False)
+'''
+
+
+@pytest.mark.pure_unit
+def test_parse_themes_from_py_basic():
+    """Parsing themes.json.py returns correct ExplorerTheme instances."""
+    themes = parse_explorer_themes_from_py(_THEMES_PY_SAMPLE)
+    assert len(themes) == 2
+    assert themes[0].slug == "territorio-ambiente"
+    assert themes[0].name == "Territorio e ambiente"
+    assert themes[0].datasets == ["rifiuti-urbani", "capacita-rinnovabile"]
+    assert themes[1].slug == "finanza-pubblica"
+    assert themes[1].datasets == ["irpef-comunale", "entrate-stato"]
+
+
+@pytest.mark.pure_unit
+def test_parse_themes_from_py_empty_list():
+    """Empty themes list returns empty list."""
+    themes = parse_explorer_themes_from_py('themes = []')
+    assert themes == []
+
+
+@pytest.mark.pure_unit
+def test_parse_themes_from_py_invalid_syntax_raises():
+    """Malformed Python raises ValueError via ast.literal_eval."""
+    with pytest.raises(ValueError, match="Failed to evaluate"):
+        parse_explorer_themes_from_py("themes = [not valid]")
+
+
+@pytest.mark.policy
+def test_parse_themes_from_py_unmatched_brackets_raises():
+    """Unmatched bracket raises ValueError via SyntaxError from ast.parse."""
+    with pytest.raises(ValueError, match="Failed to parse themes.json.py as Python"):
+        parse_explorer_themes_from_py("themes = [not closed")
+
+
+@pytest.mark.policy
+def test_parse_themes_from_py_no_themes_var_raises():
+    """Missing 'themes' variable raises ValueError."""
+    with pytest.raises(ValueError, match="No top-level 'themes' variable found"):
+        parse_explorer_themes_from_py("print('hello')")
+
+
+@pytest.mark.contract
+def test_parse_themes_from_py_brackets_before_themes():
+    """Brackets in docstring or before 'themes =' do not confuse the parser.
+
+    The old naive bracket-matching approach would pick the first '[' in the
+    file. The AST-based approach correctly skips brackets in docstrings,
+    imports and other code.
+    """
+    py_src = '''#!/usr/bin/env python3
+"""Docstring with [brackets] inside."""
+import json, sys
+
+SOME_CONSTANT = [1, 2, 3]
+
+themes = [
+    {"slug": "test", "name": "Test", "datasets": ["ds1"]},
+]
+json.dump(themes, sys.stdout, ensure_ascii=False)
+'''
+    themes = parse_explorer_themes_from_py(py_src)
+    assert len(themes) == 1
+    assert themes[0].slug == "test"
+    assert themes[0].datasets == ["ds1"]
+    """Parse the actual themes.json.py from data-explorer (real content)."""
+    py_src = '''#!/usr/bin/env python3
+"""Data loader: temi editoriali. Mappa slug tema \u2192 slug dataset."""
+import json, sys
+
+themes = [
+    {
+        "slug": "territorio-ambiente",
+        "name": "Territorio e ambiente",
+        "description": "Trasformazioni territoriali, ambiente, energia e rifiuti",
+        "datasets": ["rifiuti-urbani", "capacita-rinnovabile"],
+        "questions": [
+            "Come varia la raccolta differenziata tra territori?",
+            "Come cambia il mix elettrico regionale tra fonti fossili e rinnovabili?",
+        ],
+    },
+    {
+        "slug": "finanza-pubblica",
+        "name": "Finanza pubblica",
+        "description": "Entrate dello Stato, capacit\u00e0 fiscale e tributi locali",
+        "datasets": ["irpef-comunale", "entrate-stato"],
+        "questions": [
+            "Come si distribuisce la capacit\u00e0 fiscale tra regioni?",
+            "Quali sono le principali voci di entrata dello Stato?",
+        ],
+    },
+    {
+        "slug": "sanita",
+        "name": "Sanit\u00e0",
+        "description": "Spesa farmaceutica, consumi sanitari e prevenzione",
+        "datasets": ["spesa-farmaceutica"],
+        "questions": ["Come cambia tra regioni la spesa farmaceutica per classi terapeutiche?"],
+    },
+    {
+        "slug": "welfare-lavoro",
+        "name": "Welfare e lavoro",
+        "description": "Pubblico impiego, pensioni e previdenza",
+        "datasets": ["dipendenti-pubblici", "pensioni-inps"],
+        "questions": [
+            "La crescita del pubblico impiego \u00e8 diffusa o concentrata in pochi comparti?",
+            "Come sono distribuite le pensioni tra gestioni previdenziali?",
+        ],
+    },
+    {
+        "slug": "giustizia",
+        "name": "Giustizia",
+        "description": "Flussi civili, tempi e carichi dei tribunali",
+        "datasets": ["flussi-giustizia-civile"],
+        "questions": ["Come si distribuisce il carico civile tra i distretti italiani?"],
+    },
+]
+
+json.dump(themes, sys.stdout, ensure_ascii=False)
+'''
+    themes = parse_explorer_themes_from_py(py_src)
+    assert len(themes) == 5
+    slugs = [t.slug for t in themes]
+    assert slugs == [
+        "territorio-ambiente", "finanza-pubblica",
+        "sanita", "welfare-lavoro", "giustizia",
+    ]
+    assert themes[2].datasets == ["spesa-farmaceutica"]
+    assert themes[3].name == "Welfare e lavoro"


### PR DESCRIPTION
## Contesto

Con la migrazione a Observable Framework (PR #98 in data-explorer), il file statico `catalog/themes.json` è stato rimosso. I temi editoriali ora vivono in `src/data/themes.json.py` — un data loader Python eseguito a build time.

ACB consumava il vecchio URL → 404 → `fetch_themes()` restituiva `None` → sezione EXPLORER persa in tutti e 3 gli artifact (`workspace_triage.json`, `topic_index.json`, `session_bootstrap.md`).

## Fix

**Opzione E2** — parsing statico del file Python invece di fetchare JSON inesistente:

- `sources/de.py`: `fetch_themes()` ora fetcha `src/data/themes.json.py` da raw GitHub
- `signals.py`: nuova funzione `parse_explorer_themes_from_py()` che estrae la lista `themes` tramite bracket matching + `ast.literal_eval` (sicuro — non esegue codice, solo letterali Python)
- Rimossa `parse_explorer_themes()` (precedente versione JSON, orfana)

## Cosa torna a funzionare

- `workspace_triage.json → explorer:` block con temi, conteggi e gap analysis
- `session_bootstrap.md → EXPLORER section` con temi, dataset associati e gap analysis
- `topic_index.json → explorer_themes` popolato

## Perché funziona

- `ast.literal_eval` è sicuro: valuta solo letterali Python (liste, dict, stringhe)
- Il file `themes.json.py` ha struttura stabile e prevedibile — lista hardcoded
- Zero modifiche in data-explorer — contratto vivo
- Stessa graceful degradation: se il file non è raggiungibile → `None` → sezione omessa
- Dopo il merge, la CI ricostruisce gli artifact automaticamente

## Test

```
80 passed in 1.44s
```
Coverage `signals.py`: 91% → 97%.

6 nuovi test per `parse_explorer_themes_from_py`: basic, empty, syntax error, unmatched brackets, no list, real file.

Closes #41
