### PR TITLE
feat: aggiunge lab-connectors ai repo tracciati da ACB

### DIFF
--- a/dataciviclab.config.yml
+++ b/dataciviclab.config.yml
@@ -19,6 +19,7 @@ repos:
   - toolkit
   - data-explorer
   - source-observatory
+  - lab-connectors
 
 # Hint operativi per agenti — descrivono flussi, non repo o dataset
 # (repo descriptions vengono da GitHub API, dataset da clean_catalog)
@@ -43,3 +44,15 @@ topics:
       - dataciviclab/docs/dataset-project-flow.md
       - dataset-incubator/PROMOTION_CHECKLIST.md
     next: Vedi dataset-project-flow.md per il ciclo intake → promozione
+
+  infrastructure:
+    summary: Foundation tecnica condivisa — HTTP client, GCS paths, MCP core
+    repos:
+      - lab-connectors
+      - toolkit
+      - data-explorer
+    paths:
+      - lab-connectors/lab_connectors/http/
+      - lab-connectors/lab_connectors/gcs/paths.py
+      - lab-connectors/lab_connectors/mcp/
+    next: lab-connectors è dipendenza pip di toolkit, data-explorer e ACB


### PR DESCRIPTION
## Cosa cambia

**`dataciviclab.config.yml`**:
- Aggiunto `lab-connectors` alla lista `repos` (7 repo ora tracciati)
- Aggiunto topic `infrastructure` per raggruppare foundation tecnica condivisa

## Perché

`lab-connectors` è il package Python condiviso del Lab (HTTP client, GCS paths, MCP core tools, DuckDB context manager). È usato come dipendenza pip da:
- `toolkit`
- `data-explorer`
- `source-observatory`
- `agent-context-builder` stesso

Ha contratti cross-repo reali (API pubbliche, path GCS) che possono rompere consumer downstream. Finora era un punto cieco per ACB.

## Topic infrastructure

Collega `lab-connectors` ai suoi principali consumer (`toolkit`, `data-explorer`) così che un agente che cerca "dov'è definito il path contract GCS" possa trovarlo rapidamente.

## Test

Nessun test da modificare — è solo configurazione dichiarativa. Il CI build verificherà che `agent-context build` parta con 7 repo invece di 6.
