### PR TITLE
feat: topic_index v3 — analyses da dataciviclab + sezione ANALYSES in bootstrap + MCP resolve

### DIFF
--- a/dataciviclab.config.yml
+++ b/dataciviclab.config.yml
@@ -56,3 +56,11 @@ topics:
       - lab-connectors/lab_connectors/gcs/paths.py
       - lab-connectors/lab_connectors/mcp/
     next: lab-connectors è dipendenza pip di toolkit, data-explorer e ACB
+
+  analyses:
+    summary: Analisi pubbliche su dati civici — dal dataset al racconto
+    repos:
+      - dataciviclab
+    paths:
+      - dataciviclab/analisi/
+    next: Vedi analisi/registry/active.md per filoni attivi

--- a/schemas/topic_index-v2.md
+++ b/schemas/topic_index-v2.md
@@ -1,7 +1,9 @@
-# topic_index.json — Schema v2
+# topic_index.json — Schema v3
 
 Artifact generato da ACB e pubblicato sul branch `context` di `agent-context-builder`.
-Sostituisce la struttura v1 (campo `topics` flat).
+Sostituisce la struttura v1 (campo `topics` flat) e v2.
+
+**Schema version**: `3` quando `analyses` è presente, `2` altrimenti (backward compat).
 
 ---
 
@@ -9,39 +11,59 @@ Sostituisce la struttura v1 (campo `topics` flat).
 
 ```json
 {
-  "schema_version": 2,
-  "generated_at": "2026-04-20T10:00:00",
+  "schema_version": 3,
+  "generated_at": "2026-05-29T10:00:00",
   "repos": {
     "dataset-incubator": {
       "description": "Dataset candidati e pipeline di incubazione",
       "url": "https://github.com/dataciviclab/dataset-incubator"
     },
-    "source-observatory": {
-      "description": "Intelligence fonti: radar, inventory, catalog-watch",
-      "url": "https://github.com/dataciviclab/source-observatory"
+    "dataciviclab": {
+      "description": "Hub pubblico del Lab",
+      "url": "https://github.com/dataciviclab/dataciviclab"
     }
   },
   "datasets_by_source": {
-    "mef": [
+    "ISPRA": [
       {
-        "slug": "irpef-comunale",
-        "name": "IRPEF Comunale 2019-2023",
-        "period": {
-          "start": 2019,
-          "end": 2023
-        },
-        "visibility": "public",
+        "slug": "ispra_ru_base",
+        "name": "ISPRA - Rifiuti Urbani (dati base)",
+        "period": { "start": 2020, "end": 2024 }
+      }
+    ]
+  },
+  "candidates_by_source": {
+    "INPS - OpenData": [
+      {
+        "slug": "pensioni_pa_dag",
+        "name": "Pensioni Pa Dag",
+        "period": { "start": 2024, "end": 2024 }
       }
     ]
   },
   "operational_topics": {
-    "datasets": {
-      "name": "datasets",
-      "summary": "Incubazione dataset",
-      "repos": ["dataset-incubator", "dataciviclab"],
-      "paths": ["dataset-incubator/", "dataciviclab/analisi/"],
-      "next": "Vedere pipeline_signals.json per stato candidati"
+    "analyses": {
+      "name": "analyses",
+      "summary": "Analisi pubbliche su dati civici",
+      "repos": ["dataciviclab"],
+      "paths": ["dataciviclab/analisi/"],
+      "next": "Vedi analisi/registry/active.md"
     }
+  },
+  "explorer_themes": [
+    { "slug": "finanza-pubblica", "name": "Finanza pubblica", "datasets": ["irpef-comunale", "entrate-stato"] }
+  ],
+  "analyses": [
+    {
+      "slug": "aifa-spesa-consumo",
+      "name": "AIFA Spesa farmaceutica convenzionata 2018-2024",
+      "datasets": ["aifa_spesa_consumo"],
+      "path": "analisi/aifa-spesa-consumo/README.md",
+      "status": "active"
+    }
+  ],
+  "analyses_by_dataset": {
+    "aifa_spesa_consumo": ["aifa-spesa-consumo"]
   }
 }
 ```
@@ -50,13 +72,17 @@ Sostituisce la struttura v1 (campo `topics` flat).
 
 ## Campi radice
 
-| Campo | Tipo | Descrizione |
-|-------|------|-------------|
-| `schema_version` | `2` | Versione dello schema (intero) |
-| `generated_at` | ISO 8601 | Timestamp di generazione |
-| `repos` | object | Mappa `repo_name → { description, url }` |
-| `datasets_by_source` | object | Dataset clean raggruppati per fonte |
-| `operational_topics` | object | Topic YAML-defined per navigazione agente |
+| Campo | Tipo | Schema | Descrizione |
+|-------|------|--------|-------------|
+| `schema_version` | `int` | v2+ | `2` o `3` (3 se analyses presenti) |
+| `generated_at` | ISO 8601 | v2+ | Timestamp di generazione |
+| `repos` | object | v2+ | Mappa `repo_name → { description, url }` |
+| `datasets_by_source` | object | v2+ | Dataset `published` raggruppati per fonte |
+| `candidates_by_source` | object | v2+ | Dataset `incubating` raggruppati per fonte |
+| `operational_topics` | object | v2+ | Topic YAML-defined per navigazione agente |
+| `explorer_themes` | array | v2+ | Temi editoriali da data-explorer |
+| `analyses` | array | **v3** | Lista analisi da `dataciviclab/analisi/` |
+| `analyses_by_dataset` | object | **v3** | Reverse lookup: dataset_slug → analysis slugs |
 
 ## `repos`
 
@@ -67,16 +93,15 @@ Chiave: nome del repository GitHub configurato in ACB.
 | `description` | string \| null | Descrizione del repo da GitHub |
 | `url` | string \| null | URL GitHub del repo |
 
-## `datasets_by_source`
+## `datasets_by_source` / `candidates_by_source`
 
-Chiave: nome della fonte (es. `"mef"`, `"istat"`). Valore: lista di dataset con `status == clean_ready` da `clean_catalog.json`.
+Chiave: nome della fonte (es. `"ISPRA"`, `"ISTAT"`). Valore: lista di dataset.
 
 | Campo | Tipo | Descrizione |
 |-------|------|-------------|
 | `slug` | string | Identificatore stabile del dataset |
 | `name` | string | Nome leggibile |
 | `period` | object \| null | Periodo del dataset come oggetto `{start, end}` |
-| `visibility` | string | `public` / `private` |
 
 ## `operational_topics`
 
@@ -89,3 +114,28 @@ Chiave: nome del topic (da `dataciviclab.config.yml`).
 | `repos` | array | Repo rilevanti |
 | `paths` | array | Path suggeriti per esplorazione |
 | `next` | string | Prima azione consigliata a un agente |
+
+## `analyses` (v3)
+
+Lista di analisi pubblicate in `dataciviclab/analisi/`.
+
+| Campo | Tipo | Descrizione |
+|-------|------|-------------|
+| `slug` | string | Identificatore stabile dell'analisi (nome directory) |
+| `name` | string | Titolo leggibile (da frontmatter README.md) |
+| `datasets` | array | Slug dei dataset clean analizzati |
+| `path` | string | Path relativo nel repo `dataciviclab` |
+| `status` | string | `active` / `archived` |
+| `discussion` | int \| null | Numero GitHub Discussion collegata (opzionale) |
+| `issue` | int \| null | Numero GitHub Issue collegata (opzionale) |
+
+## `analyses_by_dataset` (v3)
+
+Reverse lookup: chiave = dataset slug, valore = lista di analysis slugs.
+
+```json
+{
+  "aifa_spesa_consumo": ["aifa-spesa-consumo"],
+  "bdap_entrate_stato": ["entrate-stato"]
+}
+```

--- a/src/agent_context_builder/mcp_server.py
+++ b/src/agent_context_builder/mcp_server.py
@@ -129,14 +129,16 @@ def _get_env(name: str) -> str | None:
 
 def _tool_error(tool: str, path: str, message: str, status_code: int | None = None) -> str:
     """Return a structured JSON error string for tool failures."""
-    return json.dumps({
-        "ok": False,
-        "tool": tool,
-        "path": path,
-        "error": message,
-        "status_code": status_code,
-        "ts": datetime.now(timezone.utc).isoformat(),
-    })
+    return json.dumps(
+        {
+            "ok": False,
+            "tool": tool,
+            "path": path,
+            "error": message,
+            "status_code": status_code,
+            "ts": datetime.now(timezone.utc).isoformat(),
+        }
+    )
 
 
 def _fetch(path: str, retries: int = 1, backoff: float = 1.0) -> str:
@@ -170,8 +172,10 @@ def session_bootstrap() -> str:
         return _fetch("session_bootstrap.md")
     except Exception as e:
         return _tool_error(
-            "session_bootstrap", "session_bootstrap.md", str(e),
-            e.response.status_code if isinstance(e, requests.HTTPError) and e.response else None
+            "session_bootstrap",
+            "session_bootstrap.md",
+            str(e),
+            e.response.status_code if isinstance(e, requests.HTTPError) and e.response else None,
         )
 
 
@@ -182,21 +186,113 @@ def workspace_triage() -> str:
         return _fetch("workspace_triage.json")
     except Exception as e:
         return _tool_error(
-            "workspace_triage", "workspace_triage.json", str(e),
-            e.response.status_code if isinstance(e, requests.HTTPError) and e.response else None
+            "workspace_triage",
+            "workspace_triage.json",
+            str(e),
+            e.response.status_code if isinstance(e, requests.HTTPError) and e.response else None,
         )
 
 
 @mcp.tool()
-def topic_index() -> str:
-    """Topic index v2 — repos, datasets_by_source, operational_topics."""
+def topic_index(resolve: str | None = None) -> str:
+    """Topic index — repos, datasets_by_source, operational_topics, analyses.
+
+    Quando ``resolve`` (dataset slug, analysis slug, o source name) è
+    specificato, restituisce un sub-graph compatto con tutte le entità
+    correlate (dataset, analyses, source, explorer themes). Senza ``resolve``
+    restituisce l'index completo (schema v3).
+    """
     try:
-        return _fetch("topic_index.json")
+        raw = _fetch("topic_index.json")
     except Exception as e:
         return _tool_error(
-            "topic_index", "topic_index.json", str(e),
-            e.response.status_code if isinstance(e, requests.HTTPError) and e.response else None
+            "topic_index",
+            "topic_index.json",
+            str(e),
+            e.response.status_code if isinstance(e, requests.HTTPError) and e.response else None,
         )
+
+    if not resolve:
+        return raw
+
+    # Resolve: extract sub-graph for a single entity
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+    resolve_lower = resolve.lower()
+    result = {"resolve": resolve, "found": False}
+
+    # Search in datasets (both clean_ready and candidates)
+    for section in ("datasets_by_source", "candidates_by_source"):
+        entries = data.get(section, {})
+        for source, datasets in entries.items():
+            for ds in datasets:
+                if ds.get("slug", "").lower() == resolve_lower:
+                    result.setdefault("datasets", []).append(
+                        {
+                            "slug": ds["slug"],
+                            "name": ds.get("name", ""),
+                            "source": source,
+                            "period": ds.get("period"),
+                            "stage": "published"
+                            if section == "datasets_by_source"
+                            else "incubating",
+                        }
+                    )
+                    result["found"] = True
+                    result.setdefault("sources", []).append(source)
+
+    # Search in analyses
+    for analysis in data.get("analyses", []):
+        if analysis.get("slug", "").lower() == resolve_lower:
+            result.setdefault("analyses", []).append(analysis)
+            result["found"] = True
+        elif resolve_lower in [d.lower() for d in analysis.get("datasets", [])]:
+            result.setdefault("analyses", []).append(analysis)
+            result["found"] = True
+
+    # Add analyses_by_dataset reverse lookup for this entity
+    abd = data.get("analyses_by_dataset", {})
+    if resolve_lower in {k.lower() for k in abd}:
+        for k, v in abd.items():
+            if k.lower() == resolve_lower:
+                result.setdefault("analyses_for_dataset", []).extend(v)
+                result["found"] = True
+
+    # Search in explorer themes
+    for theme in data.get("explorer_themes", []):
+        ds_list = [d.lower() for d in theme.get("datasets", [])]
+        if resolve_lower in ds_list:
+            result.setdefault("explorer_themes", []).append(
+                {
+                    "slug": theme.get("slug"),
+                    "name": theme.get("name"),
+                }
+            )
+            result["found"] = True
+
+    # Search in sources (by source name)
+    for section in ("datasets_by_source", "candidates_by_source"):
+        entries = data.get(section, {})
+        for source in entries:
+            if source.lower() == resolve_lower:
+                result["found"] = True
+                result.setdefault("sources", []).append(source)
+                result.setdefault("datasets", []).extend(
+                    {
+                        "slug": ds["slug"],
+                        "name": ds.get("name", ""),
+                        "source": source,
+                        "period": ds.get("period"),
+                        "stage": "published" if section == "datasets_by_source" else "incubating",
+                    }
+                    for ds in entries[source]
+                )
+
+    result["ts"] = datetime.now(timezone.utc).isoformat()
+    return json.dumps(result, indent=2, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -213,26 +309,30 @@ def refresh_context() -> str:
 
     token = _get_env("GITHUB_TOKEN")
     if not token:
-        return json.dumps({
-            "ok": False,
-            "tool": "refresh_context",
-            "error": "GITHUB_TOKEN non impostato. Serve un token con scope 'workflow'.",
-            "ts": datetime.now(timezone.utc).isoformat(),
-        })
+        return json.dumps(
+            {
+                "ok": False,
+                "tool": "refresh_context",
+                "error": "GITHUB_TOKEN non impostato. Serve un token con scope 'workflow'.",
+                "ts": datetime.now(timezone.utc).isoformat(),
+            }
+        )
 
     now = time.monotonic()
     if _last_refresh_attempt is not None:
         elapsed = now - _last_refresh_attempt
         if elapsed < _REFRESH_MIN_INTERVAL:
             wait = _REFRESH_MIN_INTERVAL - elapsed
-            return json.dumps({
-                "ok": False,
-                "tool": "refresh_context",
-                "error": f"Troppo presto. Ultimo tentativo {int(elapsed)}s fa. "
-                         f"Aspetta ~{int(wait)}s prima di riprovare.",
-                "retry_after": int(wait),
-                "ts": datetime.now(timezone.utc).isoformat(),
-            })
+            return json.dumps(
+                {
+                    "ok": False,
+                    "tool": "refresh_context",
+                    "error": f"Troppo presto. Ultimo tentativo {int(elapsed)}s fa. "
+                    f"Aspetta ~{int(wait)}s prima di riprovare.",
+                    "retry_after": int(wait),
+                    "ts": datetime.now(timezone.utc).isoformat(),
+                }
+            )
 
     _last_refresh_attempt = now
     try:
@@ -247,41 +347,51 @@ def refresh_context() -> str:
         )
         if response.status_code == 204:
             _log.info("refresh_context", "triggered", ref="main")
-            return json.dumps({
-                "ok": True,
-                "tool": "refresh_context",
-                "message": "Build triggerato. Artifact aggiornati entro ~1 minuto.",
-                "ts": datetime.now(timezone.utc).isoformat(),
-            })
+            return json.dumps(
+                {
+                    "ok": True,
+                    "tool": "refresh_context",
+                    "message": "Build triggerato. Artifact aggiornati entro ~1 minuto.",
+                    "ts": datetime.now(timezone.utc).isoformat(),
+                }
+            )
         elif response.status_code == 422:
             _log.error(
-                "refresh_context", "rejected",
-                status=response.status_code, body=response.text,
+                "refresh_context",
+                "rejected",
+                status=response.status_code,
+                body=response.text,
             )
-            return json.dumps({
-                "ok": False,
-                "tool": "refresh_context",
-                "error": "Build rifiutato (422). Verifica che il workflow sia abilitato su main.",
-                "status_code": 422,
-                "ts": datetime.now(timezone.utc).isoformat(),
-            })
+            return json.dumps(
+                {
+                    "ok": False,
+                    "tool": "refresh_context",
+                    "error": "Build rifiutato (422). Verifica che il workflow sia su main.",
+                    "status_code": 422,
+                    "ts": datetime.now(timezone.utc).isoformat(),
+                }
+            )
         else:
             _log.error("refresh_context", "failed", status=response.status_code, body=response.text)
-            return json.dumps({
-                "ok": False,
-                "tool": "refresh_context",
-                "error": f"Errore {response.status_code}: {response.text}",
-                "status_code": response.status_code,
-                "ts": datetime.now(timezone.utc).isoformat(),
-            })
+            return json.dumps(
+                {
+                    "ok": False,
+                    "tool": "refresh_context",
+                    "error": f"Errore {response.status_code}: {response.text}",
+                    "status_code": response.status_code,
+                    "ts": datetime.now(timezone.utc).isoformat(),
+                }
+            )
     except requests.RequestException as e:
         _log.error("refresh_context", "network_error", error=str(e))
-        return json.dumps({
-            "ok": False,
-            "tool": "refresh_context",
-            "error": f"Errore di rete: {e}",
-            "ts": datetime.now(timezone.utc).isoformat(),
-        })
+        return json.dumps(
+            {
+                "ok": False,
+                "tool": "refresh_context",
+                "error": f"Errore di rete: {e}",
+                "ts": datetime.now(timezone.utc).isoformat(),
+            }
+        )
 
 
 def main() -> None:

--- a/src/agent_context_builder/mcp_server.py
+++ b/src/agent_context_builder/mcp_server.py
@@ -224,13 +224,30 @@ def topic_index(resolve: str | None = None) -> str:
     resolve_lower = resolve.lower()
     result = {"resolve": resolve, "found": False}
 
+    # Dedup helpers: track seen slugs to avoid duplicates across sections
+    seen_sources: set[str] = set()
+    seen_datasets: set[str] = set()
+    seen_analyses: set[str] = set()
+    seen_themes: set[str] = set()
+
+    def _add_source(source: str) -> None:
+        if source not in seen_sources:
+            seen_sources.add(source)
+            result.setdefault("sources", []).append(source)
+
+    def _add_dataset(entry: dict) -> None:
+        slug = entry["slug"]
+        if slug not in seen_datasets:
+            seen_datasets.add(slug)
+            result.setdefault("datasets", []).append(entry)
+
     # Search in datasets (both clean_ready and candidates)
     for section in ("datasets_by_source", "candidates_by_source"):
         entries = data.get(section, {})
         for source, datasets in entries.items():
             for ds in datasets:
                 if ds.get("slug", "").lower() == resolve_lower:
-                    result.setdefault("datasets", []).append(
+                    _add_dataset(
                         {
                             "slug": ds["slug"],
                             "name": ds.get("name", ""),
@@ -242,36 +259,43 @@ def topic_index(resolve: str | None = None) -> str:
                         }
                     )
                     result["found"] = True
-                    result.setdefault("sources", []).append(source)
+                    _add_source(source)
 
     # Search in analyses
     for analysis in data.get("analyses", []):
-        if analysis.get("slug", "").lower() == resolve_lower:
-            result.setdefault("analyses", []).append(analysis)
-            result["found"] = True
-        elif resolve_lower in [d.lower() for d in analysis.get("datasets", [])]:
-            result.setdefault("analyses", []).append(analysis)
-            result["found"] = True
+        a_slug = analysis.get("slug", "")
+        if a_slug.lower() == resolve_lower or resolve_lower in [
+            d.lower() for d in analysis.get("datasets", [])
+        ]:
+            if a_slug not in seen_analyses:
+                seen_analyses.add(a_slug)
+                result.setdefault("analyses", []).append(analysis)
+                result["found"] = True
 
     # Add analyses_by_dataset reverse lookup for this entity
     abd = data.get("analyses_by_dataset", {})
     if resolve_lower in {k.lower() for k in abd}:
         for k, v in abd.items():
             if k.lower() == resolve_lower:
-                result.setdefault("analyses_for_dataset", []).extend(v)
+                result.setdefault("analyses_for_dataset", []).extend(
+                    s for s in v if s not in seen_analyses
+                )
                 result["found"] = True
 
     # Search in explorer themes
     for theme in data.get("explorer_themes", []):
         ds_list = [d.lower() for d in theme.get("datasets", [])]
         if resolve_lower in ds_list:
-            result.setdefault("explorer_themes", []).append(
-                {
-                    "slug": theme.get("slug"),
-                    "name": theme.get("name"),
-                }
-            )
-            result["found"] = True
+            t_slug = theme.get("slug", "")
+            if t_slug not in seen_themes:
+                seen_themes.add(t_slug)
+                result.setdefault("explorer_themes", []).append(
+                    {
+                        "slug": t_slug,
+                        "name": theme.get("name"),
+                    }
+                )
+                result["found"] = True
 
     # Search in sources (by source name)
     for section in ("datasets_by_source", "candidates_by_source"):
@@ -279,17 +303,19 @@ def topic_index(resolve: str | None = None) -> str:
         for source in entries:
             if source.lower() == resolve_lower:
                 result["found"] = True
-                result.setdefault("sources", []).append(source)
-                result.setdefault("datasets", []).extend(
-                    {
-                        "slug": ds["slug"],
-                        "name": ds.get("name", ""),
-                        "source": source,
-                        "period": ds.get("period"),
-                        "stage": "published" if section == "datasets_by_source" else "incubating",
-                    }
-                    for ds in entries[source]
-                )
+                _add_source(source)
+                for ds in entries[source]:
+                    _add_dataset(
+                        {
+                            "slug": ds["slug"],
+                            "name": ds.get("name", ""),
+                            "source": source,
+                            "period": ds.get("period"),
+                            "stage": "published"
+                            if section == "datasets_by_source"
+                            else "incubating",
+                        }
+                    )
 
     result["ts"] = datetime.now(timezone.utc).isoformat()
     return json.dumps(result, indent=2, ensure_ascii=False)

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -146,6 +146,32 @@ class Renderer:
             lines.append("**Dataset Catalog**: unavailable")
         lines.append("")
 
+        # ── ANALYSES ──────────────────────────────────────────────────────
+        analyses = self._fetch_dcl_analyses()
+        if analyses:
+            active = [a for a in analyses if a.status == "active"]
+            archived = [a for a in analyses if a.status == "archived"]
+            lines.append("## 📊 ANALYSES")
+            lines.append("")
+            if active:
+                lines.append(f"**Attive**: {len(active)}")
+                for a in active:
+                    datasets_str = ", ".join(a.datasets) if a.datasets else ""
+                    parts = [f"**{a.name}**"]
+                    if datasets_str:
+                        parts.append(f"→ {datasets_str}")
+                    if a.discussion is not None:
+                        parts.append(
+                            f"[discussion #{a.discussion}]"
+                            f"(https://github.com/orgs/dataciviclab/discussions/{a.discussion})"
+                        )
+                    lines.append(f"  · {' · '.join(parts)}")
+            if archived:
+                lines.append(f"**Archiviate**: {len(archived)}")
+                for a in archived:
+                    lines.append(f"  · **{a.name}**")
+            lines.append("")
+
         # ── EXPLORER ──────────────────────────────────────────────────────
         explorer_themes = self._fetch_explorer_themes()
         if explorer_themes is not None:

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -10,12 +10,14 @@ from .discussions import DiscussionCollector
 from .git_local import GitLocalCollector, GitState
 from .github import PR, GitHubCollector
 from .signals import (
+    Analysis,
     DICleanCatalog,
     ExplorerTheme,
     RadarSummary,
     RepoSignals,
     SourceObservatorySignals,
 )
+from .sources.dcl import DataciviclabFetcher
 from .sources.de import DataExplorerFetcher
 from .sources.di import DatasetIncubatorFetcher
 from .sources.so import SourceObservatoryFetcher
@@ -50,6 +52,7 @@ class Renderer:
         self._so_fetcher = SourceObservatoryFetcher(self.github_collector)
         self._di_fetcher = DatasetIncubatorFetcher(self.github_collector)
         self._de_fetcher = DataExplorerFetcher(self.github_collector)
+        self._dcl_fetcher = DataciviclabFetcher(self.github_collector)
 
     def render_session_bootstrap(self) -> str:
         """Render session_bootstrap.md.
@@ -88,9 +91,7 @@ class Renderer:
                         di = f" — ↳ {', '.join(s.datasets_in_use)}" if s.datasets_in_use else ""
                         streak = f" (streak {s.red_streak})" if s.red_streak else ""
                         note = f" — {s.note}" if s.note else ""
-                        lines.append(
-                            f"  · **{s.id}** {s.status} [{s.http_code}]{note}{streak}{di}"
-                        )
+                        lines.append(f"  · **{s.id}** {s.status} [{s.http_code}]{note}{streak}{di}")
             else:
                 lines.append("**Radar**: unavailable")
 
@@ -103,7 +104,8 @@ class Renderer:
                     for s in issues:
                         action = (
                             f" — azione: {s.suggested_action}"
-                            if s.suggested_action not in ("nessuna", "") else ""
+                            if s.suggested_action not in ("nessuna", "")
+                            else ""
                         )
                         lines.append(f"  · **{s.source}** ({s.protocol}): {s.signal_type}{action}")
                 else:
@@ -129,9 +131,7 @@ class Renderer:
             lines.append(f"**Pipeline**: {total} candidates — {status_str}")
             for s in di.failed_runs:
                 run = s.sample_run
-                lines.append(
-                    f"  ⚠️ **{s.label}** — run fallito [{run.year}]({run.run_url})"
-                )
+                lines.append(f"  ⚠️ **{s.label}** — run fallito [{run.year}]({run.run_url})")
         else:
             lines.append("**Pipeline**: unavailable")
 
@@ -175,9 +175,7 @@ class Renderer:
                     catalog_published_slugs.add(ds.slug)
             gap = sorted(catalog_published_slugs - themed_slugs)
             if gap:
-                lines.append(
-                    f"  ⚠ {len(gap)} dataset published non ancora su explorer:"
-                )
+                lines.append(f"  ⚠ {len(gap)} dataset published non ancora su explorer:")
                 for slug in gap[:5]:
                     lines.append(f"    · {slug}")
                 if len(gap) > 5:
@@ -188,8 +186,11 @@ class Renderer:
             if last_deploy is not None:
                 conclusion = last_deploy.get("conclusion", "unknown")
                 icon = "✅" if conclusion == "success" else "❌"
-                completed = (last_deploy.get("completed_at", "")[:10]
-                             if last_deploy.get("completed_at") else "?")
+                completed = (
+                    last_deploy.get("completed_at", "")[:10]
+                    if last_deploy.get("completed_at")
+                    else "?"
+                )
                 lines.append(f"  **Deploy**: {icon} {conclusion} ({completed})")
             else:
                 lines.append("  **Deploy**: dati non disponibili")
@@ -269,10 +270,8 @@ class Renderer:
     def _fetch_radar_summary(self) -> RadarSummary | None:
         return self._so_fetcher.fetch_radar_summary()
 
-
     def _fetch_source_observatory_signals(self) -> SourceObservatorySignals | None:
         return self._so_fetcher.fetch_catalog_signals()
-
 
     def render_workspace_triage(self) -> dict[str, Any]:
         """Render workspace_triage.json.
@@ -291,8 +290,6 @@ class Renderer:
             de_fetcher=self._de_fetcher,
         )
 
-
-
     def _fetch_explorer_themes(self) -> list[ExplorerTheme] | None:
         return self._de_fetcher.fetch_themes()
 
@@ -301,9 +298,6 @@ class Renderer:
 
     def _fetch_di_clean_catalog(self) -> DICleanCatalog | None:
         return self._di_fetcher.fetch_clean_catalog()
-
-
-
 
     @staticmethod
     def _format_period(period: dict[str, Any]) -> str:
@@ -315,11 +309,7 @@ class Renderer:
             return str(start)
         return f"{start or '?'}-{end or '?'}"
 
-
-
-    def _collect_warnings(
-        self, prs: list[PR], repos_state: dict[str, GitState]
-    ) -> list[str]:
+    def _collect_warnings(self, prs: list[PR], repos_state: dict[str, GitState]) -> list[str]:
         """Collect warnings for triage.
 
         Args:
@@ -349,12 +339,16 @@ class Renderer:
         return warnings
 
     def render_topic_index(self) -> dict[str, Any]:
-        """Render topic_index.json.
+        """Render topic_index.json (schema v3).
 
         Returns:
             - repos: GitHub description per repo (auto from API)
             - datasets_by_source: clean_ready datasets grouped by source (auto from catalog)
+            - candidates_by_source: incubating datasets grouped by source
             - operational_topics: YAML-defined topics for agent navigation
+            - explorer_themes: editorial themes from data-explorer (v2)
+            - analyses: list of analyses from dataciviclab/analisi/ (v3)
+            - analyses_by_dataset: reverse lookup dataset → analyses (v3)
         """
         # Repos with description from GitHub
         repos_info = self.github_collector.get_repos_info(self.config.repos)
@@ -367,21 +361,27 @@ class Renderer:
         catalog = self._fetch_di_clean_catalog()
         datasets_by_source: dict[str, list[dict[str, Any]]] = {}
         candidates_by_source: dict[str, list[dict[str, Any]]] = {}
+        all_dataset_slugs: set[str] = set()
         if catalog:
             for ds in catalog.clean_ready:
                 source = ds.source or "unknown"
-                datasets_by_source.setdefault(source, []).append({
-                    "slug": ds.slug,
-                    "name": ds.name,
-                    "period": ds.period,
-                })
+                datasets_by_source.setdefault(source, []).append(
+                    {
+                        "slug": ds.slug,
+                        "name": ds.name,
+                        "period": ds.period,
+                    }
+                )
+                all_dataset_slugs.add(ds.slug)
             for ds in catalog.candidates:
                 source = ds.source or "unknown"
-                candidates_by_source.setdefault(source, []).append({
-                    "slug": ds.slug,
-                    "name": ds.name,
-                    "period": ds.period,
-                })
+                candidates_by_source.setdefault(source, []).append(
+                    {
+                        "slug": ds.slug,
+                        "name": ds.name,
+                        "period": ds.period,
+                    }
+                )
 
         # YAML-defined operational topics (agent navigation hints)
         operational_topics = {}
@@ -407,8 +407,34 @@ class Renderer:
                 for t in explorer_themes
             ]
 
-        return {
-            "schema_version": 2,
+        # ── v3: Analyses from dataciviclab ──────────────────────────────
+        analyses_list: list[dict[str, Any]] = []
+        analyses_by_dataset: dict[str, list[str]] = {}
+        analyses = self._fetch_dcl_analyses()
+        if analyses:
+            for a in analyses:
+                entry: dict[str, Any] = {
+                    "slug": a.slug,
+                    "name": a.name,
+                    "datasets": a.datasets,
+                    "path": a.path,
+                    "status": a.status,
+                }
+                if a.discussion is not None:
+                    entry["discussion"] = a.discussion
+                if a.issue is not None:
+                    entry["issue"] = a.issue
+                analyses_list.append(entry)
+
+                # Build reverse lookup: dataset_slug → [analysis_slug, ...]
+                for ds in a.datasets:
+                    analyses_by_dataset.setdefault(ds, []).append(a.slug)
+
+        # Determine schema version: 3 if we have analyses, 2 otherwise
+        schema_version = 3 if analyses_list else 2
+
+        result: dict[str, Any] = {
+            "schema_version": schema_version,
             "generated_at": self.fixed_timestamp,
             "repos": repos_section,
             "datasets_by_source": datasets_by_source,
@@ -416,3 +442,14 @@ class Renderer:
             "operational_topics": operational_topics,
             "explorer_themes": explorer_themes_list,
         }
+
+        if analyses_list:
+            result["analyses"] = analyses_list
+            result["analyses_by_dataset"] = analyses_by_dataset
+
+        return result
+
+    def _fetch_dcl_analyses(self) -> list[Analysis]:
+        """Fetch analyses from dataciviclab via DCL fetcher."""
+        data = self._dcl_fetcher.fetch()
+        return data.analyses

--- a/src/agent_context_builder/signals.py
+++ b/src/agent_context_builder/signals.py
@@ -46,7 +46,8 @@ class SourceObservatorySignals:
     def drift_alerts(self) -> list[SourceSignal]:
         """Signals that should surface in the catalog drift section."""
         return [
-            s for s in self.signals
+            s
+            for s in self.signals
             if s.signal_type
             in ("inventory change", "structural drift", "missing_data", "follow-up candidate")
         ]
@@ -97,8 +98,7 @@ class RepoSignals:
     def failed_runs(self) -> list[RepoSignal]:
         """Signals with a failed sample_run (shown in bootstrap)."""
         return [
-            s for s in self.signals
-            if s.sample_run is not None and s.sample_run.status == "failed"
+            s for s in self.signals if s.sample_run is not None and s.sample_run.status == "failed"
         ]
 
 
@@ -324,6 +324,22 @@ class RadarSummary:
 
 
 @dataclass
+class Analysis:
+    """Analysis entry from dataciviclab/analisi/.
+
+    Parsed from the analysis README.md frontmatter and registry/active.md.
+    """
+
+    slug: str
+    name: str
+    datasets: list[str] = field(default_factory=list)
+    discussion: int | None = None
+    issue: int | None = None
+    path: str = ""
+    status: str = "active"
+
+
+@dataclass
 class ExplorerTheme:
     """Single theme entry from data-explorer editorial themes."""
 
@@ -374,9 +390,7 @@ def parse_explorer_themes_from_py(raw_py: str) -> list[ExplorerTheme]:
             break
 
     if themes_value is None:
-        raise ValueError(
-            "No top-level 'themes' variable found in themes.json.py"
-        )
+        raise ValueError("No top-level 'themes' variable found in themes.json.py")
 
     try:
         data: list[dict[str, Any]] = ast.literal_eval(themes_value)
@@ -384,9 +398,7 @@ def parse_explorer_themes_from_py(raw_py: str) -> list[ExplorerTheme]:
         raise ValueError(f"Failed to evaluate themes literal: {exc}") from exc
 
     if not isinstance(data, list):
-        raise ValueError(
-            f"Expected list literal for themes, got {type(data).__name__}"
-        )
+        raise ValueError(f"Expected list literal for themes, got {type(data).__name__}")
 
     return [
         ExplorerTheme(

--- a/src/agent_context_builder/sources/dcl.py
+++ b/src/agent_context_builder/sources/dcl.py
@@ -1,0 +1,227 @@
+"""Dataciviclab hub fetcher — analyses registry, analysis READMEs.
+
+Fetches and parses artifacts from the ``dataciviclab`` hub repository:
+
+- ``analisi/registry/active.md`` — markdown table mapping analysis slugs
+  to discussions and issues.
+- ``analisi/{slug}/README.md`` — analysis page with YAML frontmatter
+  containing ``dataset_slug``, ``title``, ``status``, ``topics``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..github import GitHubCollector
+from ..signals import Analysis
+
+_REPO = "dataciviclab"
+_REGISTRY_PATH = "analisi/registry/active.md"
+
+
+@dataclass
+class DataciviclabData:
+    """Cached dataciviclab artifact bundle."""
+
+    analyses: list[Analysis] = field(default_factory=list)
+
+
+class DataciviclabFetcher:
+    """Fetch dataciviclab artifacts from GitHub raw URLs."""
+
+    def __init__(self, collector: GitHubCollector):
+        self.collector = collector
+        self._cache: list[Analysis] | None | object = _UNSET
+
+    def fetch(self) -> DataciviclabData:
+        """Fetch all dataciviclab artifacts."""
+        return DataciviclabData(analyses=self.fetch_analyses())
+
+    def fetch_analyses(self) -> list[Analysis]:
+        """Parse analyses from dataciviclab/analisi/.
+
+        Strategy:
+        1. Fetch ``analisi/registry/active.md`` and parse the markdown
+           table to get ``{slug, discussion, issue}``.
+        2. For each analysis slug, fetch
+           ``analisi/{slug}/README.md`` and extract YAML frontmatter
+           (``dataset_slug``, ``title``, ``status``).
+        """
+        if self._cache is not _UNSET:
+            return self._cache  # type: ignore[return-value]
+
+        raw_registry = self.collector.get_raw_file(_REPO, _REGISTRY_PATH)
+        if raw_registry is None:
+            self._cache = []
+            return []
+
+        registry_entries = _parse_active_md(raw_registry)
+        analyses: list[Analysis] = []
+
+        for slug, discussion, issue in registry_entries:
+            readme_path = f"analisi/{slug}/README.md"
+            raw_readme = self.collector.get_raw_file(_REPO, readme_path)
+
+            if raw_readme is None:
+                # Fallback: infer datasets from slug
+                fallback_datasets = _slug_to_datasets(slug)
+                analyses.append(
+                    Analysis(
+                        slug=slug,
+                        name=slug,
+                        datasets=fallback_datasets,
+                        status="active",
+                        discussion=discussion,
+                        issue=issue,
+                        path=readme_path,
+                    )
+                )
+                continue
+
+            frontmatter = _parse_frontmatter(raw_readme)
+            datasets = _resolve_datasets(frontmatter, slug)
+            name = frontmatter.get("title", slug)
+            status = frontmatter.get("status", "active")
+
+            analyses.append(
+                Analysis(
+                    slug=slug,
+                    name=name,
+                    datasets=datasets,
+                    discussion=discussion,
+                    issue=issue,
+                    path=readme_path,
+                    status=status,
+                )
+            )
+
+        self._cache = analyses
+        return analyses
+
+
+def _parse_active_md(raw: str) -> list[tuple[str, int | None, int | None]]:
+    """Parse the markdown table from ``active.md``.
+
+    Expected format::
+
+        | filone | discussion | issue | stato |
+        |--------|------------|-------|-------|
+        | irpef-comunale | [#88](url) | --- | active |
+        | civile-flussi | --- | --- | active |
+
+    Returns a list of ``(slug, discussion_number, issue_number)``.
+    """
+    entries: list[tuple[str, int | None, int | None]] = []
+    lines = raw.splitlines()
+
+    # Find the separator line (---|---|---) and start parsing from next line
+    in_table = False
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if re.match(r"^\|[-:\s]+\|[-:\s]+\|[-:\s]+\|[-:\s]+\|$", stripped):
+            in_table = True
+            continue
+        if not in_table:
+            continue
+        if not stripped.startswith("|"):
+            continue
+
+        cells = [c.strip() for c in stripped.split("|")]
+        # Expected: | filone | discussion | issue | stato |
+        if len(cells) < 5:
+            continue
+
+        slug = cells[1].strip()
+        if not slug or slug == "filone":
+            continue
+
+        discussion = _extract_issue_number(cells[2])
+        issue = _extract_issue_number(cells[3])
+        entries.append((slug, discussion, issue))
+
+    return entries
+
+
+def _extract_issue_number(cell: str) -> int | None:
+    """Extract an issue/discussion number from a markdown link cell.
+
+    Handles ``#88``, ``[#88](url)``, ``---``, ``—``, empty.
+    """
+    cell = cell.strip()
+    if not cell or cell in ("---", "—", "-"):
+        return None
+    # Match [#N](url) or just #N
+    m = re.search(r"#(\d+)", cell)
+    if m:
+        return int(m.group(1))
+    return None
+
+
+def _parse_frontmatter(raw: str) -> dict[str, Any]:
+    """Parse YAML-like frontmatter from a markdown file.
+
+    Handles the simple key: value format used in analysis READMEs::
+
+        ---
+        title: AIFA Spesa farmaceutica convenzionata 2018-2024
+        description: ...
+        date: 2026-05-24
+        topics: sanita
+        status: active
+        dataset_slug: aifa_spesa_consumo
+        ---
+
+    Returns a dict with frontmatter keys. Does NOT use pyyaml to keep
+    the dependency profile light — the format is constrained enough for
+    simple line-based parsing.
+    """
+    result: dict[str, Any] = {}
+    lines = raw.splitlines()
+    in_frontmatter = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "---":
+            if not in_frontmatter:
+                in_frontmatter = True
+                continue
+            else:
+                # End of frontmatter
+                break
+        if not in_frontmatter:
+            continue
+        if ":" not in stripped:
+            continue
+        key, _, value = stripped.partition(":")
+        result[key.strip()] = value.strip()
+    return result
+
+
+def _slug_to_datasets(slug: str) -> list[str]:
+    """Convert an analysis slug to dataset slug(s) by convention.
+
+    The default convention replaces hyphens with underscores.
+    """
+    return [slug.replace("-", "_")]
+
+
+def _resolve_datasets(frontmatter: dict[str, Any], slug: str) -> list[str]:
+    """Resolve dataset slugs from an analysis frontmatter.
+
+    Uses the explicit ``dataset_slug`` field if present, otherwise
+    falls back to converting the analysis slug (hyphens → underscores).
+    """
+    explicit = frontmatter.get("dataset_slug")
+    if explicit:
+        return [explicit]
+    return _slug_to_datasets(slug)
+
+
+class _Unset:
+    pass
+
+
+_UNSET = _Unset()

--- a/tests/test_dcl.py
+++ b/tests/test_dcl.py
@@ -1,0 +1,206 @@
+"""Tests for sources/dcl.py — DataciviclabFetcher."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_context_builder.sources.dcl import (
+    DataciviclabFetcher,
+    _extract_issue_number,
+    _parse_active_md,
+    _parse_frontmatter,
+    _resolve_datasets,
+    _slug_to_datasets,
+)
+
+# ── _parse_active_md ────────────────────────────────────────────────────────
+
+
+def test_parse_active_md_basic():
+    """Parse standard active.md table."""
+    raw = """| filone | discussion | issue | stato |
+|--------|------------|-------|-------|
+| irpef-comunale | [#88](url) | --- | active |
+| aifa-spesa-consumo | --- | --- | active |
+"""
+    entries = _parse_active_md(raw)
+    assert len(entries) == 2
+
+    slug, discussion, issue = entries[0]
+    assert slug == "irpef-comunale"
+    assert discussion == 88
+    assert issue is None
+
+    slug, discussion, issue = entries[1]
+    assert slug == "aifa-spesa-consumo"
+    assert discussion is None
+    assert issue is None
+
+
+def test_parse_active_md_empty():
+    """Empty or no-table content returns empty list."""
+    assert _parse_active_md("") == []
+    assert _parse_active_md("No table here") == []
+
+
+def test_parse_active_md_with_issue():
+    """Parse table row that includes an issue number."""
+    raw = """| filone | discussion | issue | stato |
+|--------|------------|-------|-------|
+| malasanita | [#99](url) | [#110](url) | active |
+"""
+    entries = _parse_active_md(raw)
+    assert len(entries) == 1
+    slug, discussion, issue = entries[0]
+    assert slug == "malasanita"
+    assert discussion == 99
+    assert issue == 110
+
+
+# ── _extract_issue_number ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "cell,expected",
+    [
+        ("[#88](url)", 88),
+        ("#88", 88),
+        ("---", None),
+        ("—", None),
+        ("", None),
+        ("text", None),
+    ],
+)
+def test_extract_issue_number(cell, expected):
+    assert _extract_issue_number(cell) == expected
+
+
+# ── _parse_frontmatter ─────────────────────────────────────────────────────
+
+
+def test_parse_frontmatter_basic():
+    """Parse YAML-like frontmatter from analysis README."""
+    raw = """---
+title: IRPEF Comunale 2019-2023
+description: Analisi IRPEF
+date: 2026-05-24
+topics: economia, finanza-pubblica
+status: active
+dataset_slug: irpef_comunale
+---
+# Content
+"""
+    fm = _parse_frontmatter(raw)
+    assert fm["title"] == "IRPEF Comunale 2019-2023"
+    assert fm["status"] == "active"
+    assert fm["dataset_slug"] == "irpef_comunale"
+    assert "Content" not in str(fm)  # not included
+
+
+def test_parse_frontmatter_no_frontmatter():
+    """File without frontmatter returns empty dict."""
+    assert _parse_frontmatter("# Just content") == {}
+
+
+def test_parse_frontmatter_empty():
+    """Empty string returns empty dict."""
+    assert _parse_frontmatter("") == {}
+
+
+# ── _resolve_datasets ──────────────────────────────────────────────────────
+
+
+def test_resolve_datasets_explicit():
+    """Explicit dataset_slug in frontmatter takes precedence."""
+    fm = {"dataset_slug": "bdap_entrate_stato"}
+    assert _resolve_datasets(fm, "entrate-stato") == ["bdap_entrate_stato"]
+
+
+def test_resolve_datasets_fallback():
+    """Without explicit slug, analysis slug is converted (hyphens → underscores)."""
+    assert _resolve_datasets({}, "irpef-comunale") == ["irpef_comunale"]
+
+
+def test_slug_to_datasets_convention():
+    """_slug_to_datasets converts hyphens to underscores."""
+    assert _slug_to_datasets("aifa-spesa-consumo") == ["aifa_spesa_consumo"]
+    assert _slug_to_datasets("entrate-stato") == ["entrate_stato"]
+    assert _slug_to_datasets("dataset_slug") == ["dataset_slug"]
+
+
+# ── DataciviclabFetcher ────────────────────────────────────────────────────
+
+
+def _mock_collector(
+    registry: str | None = None, readme_map: dict[str, str] | None = None
+) -> MagicMock:
+    """Build a mock GitHubCollector with configurable raw_file responses."""
+    m = MagicMock()
+
+    def _raw_file_side_effect(repo, path, ref="main"):
+        if repo != "dataciviclab":
+            return None
+        if path == "analisi/registry/active.md":
+            return registry
+        if readme_map and path in readme_map:
+            return readme_map[path]
+        return None
+
+    m.get_raw_file.side_effect = _raw_file_side_effect
+    m.fetch_errors = {}
+    return m
+
+
+def test_fetch_analyses_basic():
+    """Fetch analyses parses registry + README frontmatter."""
+    registry = """| filone | discussion | issue | stato |
+|--------|------------|-------|-------|
+| irpef-comunale | [#88](url) | --- | active |
+"""
+    readme_map = {
+        "analisi/irpef-comunale/README.md": """---
+title: IRPEF Comunale
+dataset_slug: irpef_comunale
+status: active
+---
+# Content
+""",
+    }
+    collector = _mock_collector(registry, readme_map)
+    fetcher = DataciviclabFetcher(collector)
+    analyses = fetcher.fetch_analyses()
+
+    assert len(analyses) == 1
+    a = analyses[0]
+    assert a.slug == "irpef-comunale"
+    assert a.name == "IRPEF Comunale"
+    assert a.datasets == ["irpef_comunale"]
+    assert a.discussion == 88
+    assert a.issue is None
+    assert a.status == "active"
+
+
+def test_fetch_analyses_registry_unavailable():
+    """When registry is not fetchable, returns empty list."""
+    collector = _mock_collector(registry=None)
+    fetcher = DataciviclabFetcher(collector)
+    assert fetcher.fetch_analyses() == []
+
+
+def test_fetch_analyses_readme_unavailable():
+    """When an analysis README is not found, uses slug as name."""
+    registry = """| filone | discussion | issue | stato |
+|--------|------------|-------|-------|
+| ghost-analysis | --- | --- | active |
+"""
+    collector = _mock_collector(registry, readme_map={})
+    fetcher = DataciviclabFetcher(collector)
+    analyses = fetcher.fetch_analyses()
+
+    assert len(analyses) == 1
+    a = analyses[0]
+    assert a.slug == "ghost-analysis"
+    assert a.name == "ghost-analysis"  # fallback
+    assert a.datasets == ["ghost_analysis"]  # hyphens → underscores

--- a/tests/test_dcl.py
+++ b/tests/test_dcl.py
@@ -15,6 +15,8 @@ from agent_context_builder.sources.dcl import (
     _slug_to_datasets,
 )
 
+pytestmark = pytest.mark.pure_unit
+
 # ── _parse_active_md ────────────────────────────────────────────────────────
 
 
@@ -153,6 +155,7 @@ def _mock_collector(
     return m
 
 
+@pytest.mark.contract
 def test_fetch_analyses_basic():
     """Fetch analyses parses registry + README frontmatter."""
     registry = """| filone | discussion | issue | stato |
@@ -182,6 +185,7 @@ status: active
     assert a.status == "active"
 
 
+@pytest.mark.contract
 def test_fetch_analyses_registry_unavailable():
     """When registry is not fetchable, returns empty list."""
     collector = _mock_collector(registry=None)
@@ -189,6 +193,7 @@ def test_fetch_analyses_registry_unavailable():
     assert fetcher.fetch_analyses() == []
 
 
+@pytest.mark.contract
 def test_fetch_analyses_readme_unavailable():
     """When an analysis README is not found, uses slug as name."""
     registry = """| filone | discussion | issue | stato |

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,4 +1,5 @@
 """Tests for MCP server resources — uses FakeHttpClient for HTTP boundary."""
+
 from __future__ import annotations
 
 import json
@@ -15,8 +16,7 @@ import agent_context_builder.mcp_server as mcp_server
 # ---------------------------------------------------------------------------
 
 
-def _patch_fetch(fake: FakeHttpClient, path: str, text: str = "",
-                 status: int = 200) -> None:
+def _patch_fetch(fake: FakeHttpClient, path: str, text: str = "", status: int = 200) -> None:
     """Register a response for one of the context-branch artifact URLs.
 
     For error status codes (>= 400), ``_FakeResponse.raise_for_status()``
@@ -115,6 +115,130 @@ def test_topic_index_http_error():
     assert data["ok"] is False
     assert data["tool"] == "topic_index"
     assert data["status_code"] == 500
+
+
+# ---------------------------------------------------------------------------
+# topic_index(resolve=...) — sub-graph traversal
+# ---------------------------------------------------------------------------
+
+
+_SAMPLE_V3_INDEX = json.dumps(
+    {
+        "schema_version": 3,
+        "datasets_by_source": {
+            "ISPRA": [
+                {
+                    "slug": "ispra_ru_base",
+                    "name": "Rifiuti Urbani",
+                    "period": {"start": 2020, "end": 2024},
+                },
+            ],
+            "MEF": [
+                {
+                    "slug": "irpef_comunale",
+                    "name": "IRPEF Comunale",
+                    "period": {"start": 2019, "end": 2023},
+                },
+            ],
+        },
+        "candidates_by_source": {
+            "ISPRA": [
+                {
+                    "slug": "ispra_consumo_suolo",
+                    "name": "Consumo Suolo",
+                    "period": {"start": 2024, "end": 2024},
+                },
+            ],
+        },
+        "analyses": [
+            {
+                "slug": "irpef-comunale",
+                "name": "IRPEF Comunale 2019-2023",
+                "datasets": ["irpef_comunale"],
+                "path": "analisi/irpef-comunale/README.md",
+                "status": "active",
+                "discussion": 88,
+            },
+        ],
+        "analyses_by_dataset": {
+            "irpef_comunale": ["irpef-comunale"],
+        },
+        "explorer_themes": [
+            {
+                "slug": "finanza-pubblica",
+                "name": "Finanza pubblica",
+                "datasets": ["irpef-comunale", "entrate-stato"],
+            },
+        ],
+    }
+)
+
+
+@pytest.mark.contract
+def test_topic_index_resolve_by_dataset_slug():
+    """resolve finds a published dataset and its related analyses."""
+    fake = FakeHttpClient()
+    _patch_fetch(fake, "topic_index.json", text=_SAMPLE_V3_INDEX)
+
+    with patch("agent_context_builder.mcp_server.HttpClient") as mock_cls:
+        mock_cls.return_value = fake
+        result = mcp_server.topic_index(resolve="irpef_comunale")
+
+    data = json.loads(result)
+    assert data["resolve"] == "irpef_comunale"
+    assert data["found"] is True
+    # Published dataset found
+    assert len(data["datasets"]) == 1
+    assert data["datasets"][0]["slug"] == "irpef_comunale"
+    assert data["datasets"][0]["stage"] == "published"
+    # Analysis found via datasets list match (irpef_comunale in analysis.datasets)
+    assert len(data["analyses"]) == 1
+    assert data["analyses"][0]["slug"] == "irpef-comunale"
+    # No duplicates in analyses
+    assert len(data["analyses"]) == 1
+
+
+@pytest.mark.contract
+def test_topic_index_resolve_by_source_dedup():
+    """resolve by source name deduplicates datasets and sources across sections."""
+    fake = FakeHttpClient()
+    _patch_fetch(fake, "topic_index.json", text=_SAMPLE_V3_INDEX)
+
+    with patch("agent_context_builder.mcp_server.HttpClient") as mock_cls:
+        mock_cls.return_value = fake
+        result = mcp_server.topic_index(resolve="ISPRA")
+
+    data = json.loads(result)
+    assert data["resolve"] == "ISPRA"
+    assert data["found"] is True
+
+    # sources should appear exactly once
+    assert len(data["sources"]) == 1
+    assert data["sources"] == ["ISPRA"]
+
+    # datasets should include both published and incubating, deduped
+    slugs = [d["slug"] for d in data["datasets"]]
+    assert len(slugs) == 2
+    assert "ispra_ru_base" in slugs
+    assert "ispra_consumo_suolo" in slugs
+    stages = {d["slug"]: d["stage"] for d in data["datasets"]}
+    assert stages["ispra_ru_base"] == "published"
+    assert stages["ispra_consumo_suolo"] == "incubating"
+
+
+@pytest.mark.contract
+def test_topic_index_resolve_not_found():
+    """resolve returns found=False when nothing matches."""
+    fake = FakeHttpClient()
+    _patch_fetch(fake, "topic_index.json", text=_SAMPLE_V3_INDEX)
+
+    with patch("agent_context_builder.mcp_server.HttpClient") as mock_cls:
+        mock_cls.return_value = fake
+        result = mcp_server.topic_index(resolve="nonexistent")
+
+    data = json.loads(result)
+    assert data["resolve"] == "nonexistent"
+    assert data["found"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,4 +1,5 @@
 """Tests for render module."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -35,7 +36,8 @@ def _r(config, gh=None, git_state=None, disc=None):
 def _cfg(root=None, repos=None):
     """Shortcut: Config with workspace_root, github_org, repos."""
     return Config(
-        workspace_root=root, github_org="test-org",
+        workspace_root=root,
+        github_org="test-org",
         repos=repos or ["repo1"],
     )
 
@@ -47,7 +49,8 @@ def test_render_session_bootstrap():
     """Test session_bootstrap.md rendering."""
     config = Config(
         workspace_root=Path("/tmp/test"),
-        github_org="test-org", repos=["repo1", "repo2"],
+        github_org="test-org",
+        repos=["repo1", "repo2"],
     )
     repos_state = {"repo1": _UNAVAILABLE, "repo2": _UNAVAILABLE}
     bootstrap = _r(config, git_state=repos_state).render_session_bootstrap()
@@ -61,8 +64,9 @@ def test_render_session_bootstrap():
 def test_render_session_bootstrap_github_error():
     """Bootstrap shows warning when GitHub fetch fails."""
     gh = make_github_mock(fetch_errors={"repo1:prs": "403 rate limit exceeded"})
-    bootstrap = _r(_cfg(root=Path("/tmp/test")), gh=gh,
-                   git_state={"repo1": _UNAVAILABLE}).render_session_bootstrap()
+    bootstrap = _r(
+        _cfg(root=Path("/tmp/test")), gh=gh, git_state={"repo1": _UNAVAILABLE}
+    ).render_session_bootstrap()
 
     assert "## 📥 INTAKE" in bootstrap
     assert "Pipeline" in bootstrap
@@ -72,16 +76,26 @@ def test_render_session_bootstrap_github_error():
 def test_render_session_bootstrap_groups_dependabot_prs():
     """Bootstrap keeps Dependabot PRs compact and leaves feature PRs visible."""
     prs = [
-        PR(1, "feat: improve context", "repo1",
-           "https://example.test/pr/1", author="gabry"),
-        PR(2, "chore(deps): bump package", "repo1",
-           "https://example.test/pr/2", author="dependabot[bot]"),
-        PR(3, "chore(deps): bump action", "repo1",
-           "https://example.test/pr/3", author="dependabot[bot]"),
+        PR(1, "feat: improve context", "repo1", "https://example.test/pr/1", author="gabry"),
+        PR(
+            2,
+            "chore(deps): bump package",
+            "repo1",
+            "https://example.test/pr/2",
+            author="dependabot[bot]",
+        ),
+        PR(
+            3,
+            "chore(deps): bump action",
+            "repo1",
+            "https://example.test/pr/3",
+            author="dependabot[bot]",
+        ),
     ]
     gh = make_github_mock(prs=prs)
-    bootstrap = _r(_cfg(root=Path("/tmp/test")), gh=gh,
-                   git_state={"repo1": _UNAVAILABLE}).render_session_bootstrap()
+    bootstrap = _r(
+        _cfg(root=Path("/tmp/test")), gh=gh, git_state={"repo1": _UNAVAILABLE}
+    ).render_session_bootstrap()
 
     assert "feat: improve context" in bootstrap
     assert "**Dependabot**: 2 bump PR(s)" in bootstrap
@@ -93,8 +107,9 @@ def test_render_session_bootstrap_groups_dependabot_prs():
 
 def test_render_workspace_triage():
     """Test workspace_triage.json rendering with no errors."""
-    triage = _r(_cfg(root=Path("/tmp/test")),
-                git_state={"repo1": _UNAVAILABLE}).render_workspace_triage()
+    triage = _r(
+        _cfg(root=Path("/tmp/test")), git_state={"repo1": _UNAVAILABLE}
+    ).render_workspace_triage()
 
     assert "generated_at" in triage
     assert triage["open_prs"] == 0
@@ -107,8 +122,9 @@ def test_render_workspace_triage_github_error():
     """Triage shows null counts and errors when GitHub fetch fails."""
     errors = {"repo1:prs": "403 rate limit exceeded"}
     gh = make_github_mock(fetch_errors=errors)
-    triage = _r(_cfg(root=Path("/tmp/test")), gh=gh,
-                git_state={"repo1": _UNAVAILABLE}).render_workspace_triage()
+    triage = _r(
+        _cfg(root=Path("/tmp/test")), gh=gh, git_state={"repo1": _UNAVAILABLE}
+    ).render_workspace_triage()
 
     assert triage["open_prs"] is None
     assert triage["open_issues"] is None
@@ -119,13 +135,18 @@ def test_render_workspace_triage_github_error():
 def test_render_workspace_triage_git_state_reason():
     """Git state includes available and reason for unavailable repos."""
     from agent_context_builder.git_local import GitState
+
     repos_state = {
-        "repo1": GitState(available=True, reason=None, dirty=True,
-                          current_branch="main",
-                          branches_ahead=["main"], untracked_files=2),
+        "repo1": GitState(
+            available=True,
+            reason=None,
+            dirty=True,
+            current_branch="main",
+            branches_ahead=["main"],
+            untracked_files=2,
+        ),
     }
-    triage = _r(_cfg(root=Path("/tmp/test")),
-                git_state=repos_state).render_workspace_triage()
+    triage = _r(_cfg(root=Path("/tmp/test")), git_state=repos_state).render_workspace_triage()
 
     r1 = triage["git_state"]["repo1"]
     assert r1["available"] is True
@@ -139,18 +160,23 @@ def test_render_workspace_triage_git_state_reason():
 
 def test_render_bootstrap_with_discussions():
     """Bootstrap includes discussions section when collector is present."""
-    config = Config(workspace_root=None, github_org="dataciviclab",
-                    repos=["dataset-incubator"])
+    config = Config(workspace_root=None, github_org="dataciviclab", repos=["dataset-incubator"])
     disc = MagicMock(spec=DiscussionCollector)
     disc.fetch_errors = {}
     disc.get_discussions.return_value = [
-        Discussion(42, "IRPEF: cosa ci dice?", "dataset-incubator",
-                   "https://github.com/dataciviclab/dataset-incubator/discussions/42",
-                   "Civic Questions", "gabry", "2026-04-14T20:00:00Z"),
+        Discussion(
+            42,
+            "IRPEF: cosa ci dice?",
+            "dataset-incubator",
+            "https://github.com/dataciviclab/dataset-incubator/discussions/42",
+            "Civic Questions",
+            "gabry",
+            "2026-04-14T20:00:00Z",
+        ),
     ]
-    bootstrap = _r(config, disc=disc,
-                   git_state={"dataset-incubator": _UNAVAILABLE}
-                   ).render_session_bootstrap()
+    bootstrap = _r(
+        config, disc=disc, git_state={"dataset-incubator": _UNAVAILABLE}
+    ).render_session_bootstrap()
 
     assert "## 🔗 OPEN" in bootstrap
     assert "IRPEF" in bootstrap
@@ -159,18 +185,23 @@ def test_render_bootstrap_with_discussions():
 
 def test_render_triage_with_discussions():
     """Triage includes open_discussions count and discussions list."""
-    config = Config(workspace_root=None, github_org="dataciviclab",
-                    repos=["dataset-incubator"])
+    config = Config(workspace_root=None, github_org="dataciviclab", repos=["dataset-incubator"])
     disc = MagicMock(spec=DiscussionCollector)
     disc.fetch_errors = {}
     disc.get_discussions.return_value = [
-        Discussion(42, "IRPEF: cosa ci dice?", "dataset-incubator",
-                   "https://github.com/...", "Civic Questions",
-                   "gabry", "2026-04-14T20:00:00Z"),
+        Discussion(
+            42,
+            "IRPEF: cosa ci dice?",
+            "dataset-incubator",
+            "https://github.com/...",
+            "Civic Questions",
+            "gabry",
+            "2026-04-14T20:00:00Z",
+        ),
     ]
-    triage = _r(config, disc=disc,
-                git_state={"dataset-incubator": _UNAVAILABLE}
-                ).render_workspace_triage()
+    triage = _r(
+        config, disc=disc, git_state={"dataset-incubator": _UNAVAILABLE}
+    ).render_workspace_triage()
 
     assert triage["open_discussions"] == 1
     assert triage["discussions"][0]["number"] == 42
@@ -178,8 +209,7 @@ def test_render_triage_with_discussions():
 
 def test_render_triage_without_discussion_collector():
     """Triage omits discussions when no collector provided."""
-    triage = _r(_cfg(),
-                git_state={"repo1": _UNAVAILABLE}).render_workspace_triage()
+    triage = _r(_cfg(), git_state={"repo1": _UNAVAILABLE}).render_workspace_triage()
 
     assert triage["open_discussions"] is None
     assert triage["discussions"] == []
@@ -209,8 +239,7 @@ def test_render_bootstrap_catalog_drift_all_stable():
 
 def test_render_bootstrap_catalog_drift_unavailable():
     """Bootstrap shows unavailable when catalog signals fetch fails."""
-    bootstrap = _r(_cfg(), gh=make_github_mock(raw_file=None)
-                   ).render_session_bootstrap()
+    bootstrap = _r(_cfg(), gh=make_github_mock(raw_file=None)).render_session_bootstrap()
 
     assert "## 📥 INTAKE" in bootstrap
     assert "Pipeline" in bootstrap
@@ -233,8 +262,7 @@ def test_render_triage_source_health_available():
 
 def test_render_triage_source_health_unavailable():
     """Triage source_health marks unavailable when fetch fails."""
-    triage = _r(_cfg(), gh=make_github_mock(raw_file=None)
-                ).render_workspace_triage()
+    triage = _r(_cfg(), gh=make_github_mock(raw_file=None)).render_workspace_triage()
 
     assert triage["source_health"]["available"] is False
 
@@ -279,16 +307,23 @@ def test_render_topic_index():
 
     config = Config(
         workspace_root=Path("/tmp/test"),
-        github_org="test-org", repos=["repo1"],
+        github_org="test-org",
+        repos=["repo1"],
         topics={
-            "toolkit": Topic(name="toolkit", repos=["repo1"], paths=["src/"],
-                             summary="Pipeline engine", next="check docs"),
+            "toolkit": Topic(
+                name="toolkit",
+                repos=["repo1"],
+                paths=["src/"],
+                summary="Pipeline engine",
+                next="check docs",
+            ),
         },
     )
     gh = make_github_mock(
         repos_info={
-            "repo1": RepoInfo(name="repo1", description="Test repo",
-                              url="https://github.com/test-org/repo1"),
+            "repo1": RepoInfo(
+                name="repo1", description="Test repo", url="https://github.com/test-org/repo1"
+            ),
         },
     )
 
@@ -352,7 +387,112 @@ def test_render_triage_dataset_catalog_available():
 
 def test_render_triage_dataset_catalog_unavailable():
     """Triage marks dataset catalog unavailable when clean_catalog fetch fails."""
-    catalog = _r(_cfg(), gh=make_github_mock(raw_file=None)
-                 ).render_workspace_triage()["dataset_catalog"]
+    catalog = _r(_cfg(), gh=make_github_mock(raw_file=None)).render_workspace_triage()[
+        "dataset_catalog"
+    ]
 
     assert catalog["available"] is False
+
+
+# ── Topic index v3: analyses ───────────────────────────────────────────────
+
+
+def _sample_active_md() -> str:
+    """Simulate dataciviclab/analisi/registry/active.md."""
+    return """| filone | discussion | issue | stato |
+|--------|------------|-------|-------|
+| irpef-comunale | [#88](https://github.com/orgs/dataciviclab/discussions/88) | --- | active |
+| aifa-spesa-consumo | --- | --- | active |
+"""
+
+
+def _sample_analysis_readme(slug: str) -> str:
+    """Simulate an analysis README.md with frontmatter."""
+    if slug == "irpef-comunale":
+        return """---
+title: IRPEF Comunale 2019-2023
+description: Analisi IRPEF
+date: 2026-05-24
+topics: economia, finanza-pubblica
+status: active
+dataset_slug: irpef_comunale
+---
+# IRPEF Comunale
+Content...
+"""
+    elif slug == "aifa-spesa-consumo":
+        return """---
+title: AIFA Spesa farmaceutica 2018-2024
+description: Spesa farmaci
+date: 2026-05-24
+topics: sanita
+status: active
+dataset_slug: aifa_spesa_consumo
+---
+# AIFA Spesa
+Content...
+"""
+    return ""
+
+
+def test_render_topic_index_v3_with_analyses():
+    """Topic index v3 includes analyses and analyses_by_dataset."""
+    config = _cfg(repos=["repo1", "dataciviclab"])
+    gh = make_github_mock()
+
+    def _raw_file_side_effect(repo, path, ref="main"):
+        if path == "registry/clean_catalog.json":
+            return sample_di_clean_catalog_json()
+        if repo == "dataciviclab" and path == "analisi/registry/active.md":
+            return _sample_active_md()
+        if repo == "dataciviclab" and path.startswith("analisi/") and path.endswith("/README.md"):
+            slug = path.split("/")[1]
+            return _sample_analysis_readme(slug)
+        return None
+
+    gh.get_raw_file.side_effect = _raw_file_side_effect
+    result = _r(config, gh=gh).render_topic_index()
+
+    assert result["schema_version"] == 3
+    assert "analyses" in result
+    assert "analyses_by_dataset" in result
+
+    # Check analyses content
+    analyses = result["analyses"]
+    assert len(analyses) == 2
+
+    irpef = next(a for a in analyses if a["slug"] == "irpef-comunale")
+    assert irpef["name"] == "IRPEF Comunale 2019-2023"
+    assert irpef["datasets"] == ["irpef_comunale"]
+    assert irpef["discussion"] == 88
+    assert irpef["status"] == "active"
+    assert "issue" not in irpef  # --- → None → omitted
+
+    aifa = next(a for a in analyses if a["slug"] == "aifa-spesa-consumo")
+    assert aifa["name"] == "AIFA Spesa farmaceutica 2018-2024"
+    assert aifa["datasets"] == ["aifa_spesa_consumo"]
+    assert "discussion" not in aifa  # None → omitted
+    assert "issue" not in aifa
+
+    # Check reverse lookup
+    abd = result["analyses_by_dataset"]
+    assert abd["irpef_comunale"] == ["irpef-comunale"]
+    assert abd["aifa_spesa_consumo"] == ["aifa-spesa-consumo"]
+
+
+def test_render_topic_index_v2_when_no_analyses():
+    """Topic index stays v2 when dataciviclab data is unavailable."""
+    config = _cfg(repos=["repo1"])
+    gh = make_github_mock(raw_file=sample_di_clean_catalog_json())
+
+    def _raw_file_side_effect(repo, path, ref="main"):
+        if path == "registry/clean_catalog.json":
+            return sample_di_clean_catalog_json()
+        return None
+
+    gh.get_raw_file.side_effect = _raw_file_side_effect
+    result = _r(config, gh=gh).render_topic_index()
+
+    assert result["schema_version"] == 2
+    assert "analyses" not in result
+    assert "analyses_by_dataset" not in result

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -289,13 +289,14 @@ def test_render_signals_cached_across_bootstrap_and_triage():
     renderer.render_session_bootstrap()
     renderer.render_workspace_triage()
 
-    assert gh.get_raw_file.call_count == 5
+    assert gh.get_raw_file.call_count == 6
     paths_fetched = [call.args[1] for call in gh.get_raw_file.call_args_list]
     assert "data/radar/radar_summary.json" in paths_fetched
     assert "data/catalog/catalog_signals.json" in paths_fetched
     assert "registry/pipeline_signals.json" in paths_fetched
     assert "registry/clean_catalog.json" in paths_fetched
     assert "src/data/themes.json.py" in paths_fetched
+    assert "analisi/registry/active.md" in paths_fetched
 
 
 # ── Topic index ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Sintesi

Aggiunge al topic index le analisi pubbliche da `dataciviclab/analisi/`, le espone nel bootstrap e aggiunge navigazione graph leggera via MCP `resolve`.

## Contesto collegato

Closes — espansione DCL mancante in ACB, discussa nel turno corrente.

## Cosa cambia

- [x] Nuovo artifact o modifica schema (topic_index v3)
- [x] Modifica builder (`sources/dcl.py`, `render.py`, `signals.py`)
- [x] Modifica configurazione (topic `analyses`)
- [x] MCP tool `topic_index()` con parametro `resolve`
- [x] Documentazione (schema v3 in `schemas/topic_index-v2.md`)

## Impatto su artifact upstream

- [x] Nessun impatto su artifact (legge solo `dataciviclab/analisi/registry/active.md` già esistente)

## Verifica

```
pytest tests/ → 100 pass
ruff check src/ → clean
Build manuale → schema_version 3, 5 analyses risolte
```

- [x] `pytest tests/` passa
- [x] `ruff check src/` passa
- [x] Build manuale verificata

## Checklist PR

- [x] Perimetro stretto: topic index + bootstrap + MCP resolve
- [x] Issue collegata o motivazione dell'assenza

## Note per chi revisiona

Backward compat: `schema_version` è `2` se analyses non disponibili. MCP `topic_index()` senza argomenti restituisce il JSON completo come prima.
