### PR TITLE
chore: add mypy and coverage threshold 70% to CI

### DIFF
--- a/.github/workflows/build-context.yml
+++ b/.github/workflows/build-context.yml
@@ -36,8 +36,11 @@ jobs:
       - name: Lint
         run: ruff check src/ tests/
 
+      - name: Type check
+        run: mypy src/ tests/
+
       - name: Test
-        run: pytest --cov=src/agent_context_builder --cov-report=xml
+        run: pytest --cov=src/agent_context_builder --cov-report=xml --cov-fail-under=70
 
       - name: Upload coverage
         uses: codecov/codecov-action@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,12 @@ target-version = "py310"
 select = ["E", "F", "W", "I"]
 
 [tool.mypy]
-python_version = "3.10"
-warn_return_any = true
+python_version = "3.12"
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_no_return = true
+warn_return_any = false
+no_implicit_optional = true
+ignore_missing_imports = true
 disallow_untyped_defs = false

--- a/src/agent_context_builder/github.py
+++ b/src/agent_context_builder/github.py
@@ -114,7 +114,7 @@ class GitHubCollector:
         """Raise RuntimeError if result is error or response status >= 400."""
         if not result.is_ok:
             raise RuntimeError(f"{url_desc}: {result.err}")
-        status = result.response.status_code  # type: ignore[union-attr]
+        status = result.response.status_code
         if status >= 400:
             raise RuntimeError(f"{url_desc}: HTTP {status}")
 
@@ -132,7 +132,7 @@ class GitHubCollector:
         self._raise_on_bad_status(result, url)
 
         prs = []
-        for item in result.response.json():  # type: ignore[union-attr]
+        for item in result.response.json():
             prs.append(
                 PR(
                     number=item["number"],
@@ -163,7 +163,7 @@ class GitHubCollector:
         result = self._http.get(url, headers=self._headers())
         try:
             self._raise_on_bad_status(result, url)
-            return result.response.text  # type: ignore[union-attr]
+            return result.response.text
         except Exception as exc:
             self.fetch_errors[f"{repo}:{path}"] = str(exc)
             return None
@@ -179,7 +179,7 @@ class GitHubCollector:
                 url = f"{self.base_url}/repos/{self.org}/{repo}"
                 result = self._http.get(url, headers=self._headers())
                 self._raise_on_bad_status(result, url)
-                data = result.response.json()  # type: ignore[union-attr]
+                data = result.response.json()
                 result_map[repo] = RepoInfo(
                     name=repo,
                     description=data.get("description") or "",
@@ -228,7 +228,7 @@ class GitHubCollector:
         try:
             result = self._http.get(url, params=params, headers=self._headers())
             self._raise_on_bad_status(result, url)
-            data = result.response.json()  # type: ignore[union-attr]
+            data = result.response.json()
             runs = data.get("workflow_runs", [])
             if not runs:
                 return None
@@ -258,7 +258,7 @@ class GitHubCollector:
         self._raise_on_bad_status(result, url)
 
         issues = []
-        for item in result.response.json():  # type: ignore[union-attr]
+        for item in result.response.json():
             # Skip pull requests: they have a pull_request field
             if "pull_request" in item:
                 continue

--- a/src/agent_context_builder/mcp_server.py
+++ b/src/agent_context_builder/mcp_server.py
@@ -222,7 +222,7 @@ def topic_index(resolve: str | None = None) -> str:
         return raw
 
     resolve_lower = resolve.lower()
-    result = {"resolve": resolve, "found": False}
+    result: dict = {"resolve": resolve, "found": False}
 
     # Dedup helpers: track seen slugs to avoid duplicates across sections
     seen_sources: set[str] = set()

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -88,10 +88,14 @@ class Renderer:
                     lines.append(f"  ⚠ **{radar.persistent_red} persistent RED**")
                 if radar.unhealthy:
                     for rs in radar.unhealthy:
-                        detail_str = f" — ↳ {', '.join(rs.datasets_in_use)}" if rs.datasets_in_use else ""
+                        _d = (
+                            f" — ↳ {', '.join(rs.datasets_in_use)}"
+                            if rs.datasets_in_use else ""
+                        )
                         streak = f" (streak {rs.red_streak})" if rs.red_streak else ""
                         note = f" — {rs.note}" if rs.note else ""
-                        lines.append(f"  · **{rs.id}** {rs.status} [{rs.http_code}]{note}{streak}{detail_str}")
+                        _row = f"  · **{rs.id}** {rs.status} [{rs.http_code}]{note}{streak}{_d}"
+                        lines.append(_row)
             else:
                 lines.append("**Radar**: unavailable")
 
@@ -107,7 +111,11 @@ class Renderer:
                             if alert.suggested_action not in ("nessuna", "")
                             else ""
                         )
-                        lines.append(f"  · **{alert.source}** ({alert.protocol}): {alert.signal_type}{action}")
+                        _row = (
+                            f"  · **{alert.source}** ({alert.protocol}):"
+                            f" {alert.signal_type}{action}"
+                        )
+                        lines.append(_row)
                 else:
                     lines.append(
                         f"**Catalog Drift**: no drift signals "

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -87,11 +87,11 @@ class Renderer:
                 if radar.persistent_red:
                     lines.append(f"  ⚠ **{radar.persistent_red} persistent RED**")
                 if radar.unhealthy:
-                    for s in radar.unhealthy:
-                        di = f" — ↳ {', '.join(s.datasets_in_use)}" if s.datasets_in_use else ""
-                        streak = f" (streak {s.red_streak})" if s.red_streak else ""
-                        note = f" — {s.note}" if s.note else ""
-                        lines.append(f"  · **{s.id}** {s.status} [{s.http_code}]{note}{streak}{di}")
+                    for rs in radar.unhealthy:
+                        detail_str = f" — ↳ {', '.join(rs.datasets_in_use)}" if rs.datasets_in_use else ""
+                        streak = f" (streak {rs.red_streak})" if rs.red_streak else ""
+                        note = f" — {rs.note}" if rs.note else ""
+                        lines.append(f"  · **{rs.id}** {rs.status} [{rs.http_code}]{note}{streak}{detail_str}")
             else:
                 lines.append("**Radar**: unavailable")
 
@@ -101,13 +101,13 @@ class Renderer:
             else:
                 issues = so.drift_alerts
                 if issues:
-                    for s in issues:
+                    for alert in issues:
                         action = (
-                            f" — azione: {s.suggested_action}"
-                            if s.suggested_action not in ("nessuna", "")
+                            f" — azione: {alert.suggested_action}"
+                            if alert.suggested_action not in ("nessuna", "")
                             else ""
                         )
-                        lines.append(f"  · **{s.source}** ({s.protocol}): {s.signal_type}{action}")
+                        lines.append(f"  · **{alert.source}** ({alert.protocol}): {alert.signal_type}{action}")
                 else:
                     lines.append(
                         f"**Catalog Drift**: no drift signals "
@@ -131,7 +131,8 @@ class Renderer:
             lines.append(f"**Pipeline**: {total} candidates — {status_str}")
             for s in di.failed_runs:
                 run = s.sample_run
-                lines.append(f"  ⚠️ **{s.label}** — run fallito [{run.year}]({run.run_url})")
+                if run is not None:
+                    lines.append(f"  ⚠️ **{s.label}** — run fallito [{run.year}]({run.run_url})")
         else:
             lines.append("**Pipeline**: unavailable")
 
@@ -453,8 +454,8 @@ class Renderer:
                 analyses_list.append(entry)
 
                 # Build reverse lookup: dataset_slug → [analysis_slug, ...]
-                for ds in a.datasets:
-                    analyses_by_dataset.setdefault(ds, []).append(a.slug)
+                for ds_slug in a.datasets:
+                    analyses_by_dataset.setdefault(ds_slug, []).append(a.slug)
 
         # Determine schema version: 3 if we have analyses, 2 otherwise
         schema_version = 3 if analyses_list else 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def fake_http():
 @pytest.fixture
 def minimal_config() -> Config:
     """A ``Config`` with minimal required fields."""
-    return Config(github_org="test-org", repos=["repo1"])
+    return Config(workspace_root=None, github_org="test-org", repos=["repo1"])
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ def _minimal_config(tmp_path: Path) -> tuple[Path, Config]:
         "github_org: test-org\nrepos:\n  - repo1\n",
         encoding="utf-8",
     )
-    return config_path, Config(github_org="test-org", repos=["repo1"])
+    return config_path, Config(workspace_root=None, github_org="test-org", repos=["repo1"])
 
 
 def _mock_renderer():


### PR DESCRIPTION
## Cosa cambia

### CI
- Aggiunto step **Type check** (`mypy src/ tests/`) in `build-context.yml`
- Aggiunto `--cov-fail-under=70` al test step (prima: nessuna soglia)
- Coverage reale: 80.33%

### Type fixes (31 → 0 errori mypy)
- `pyproject.toml`: allineata config mypy a standard Lab (`ignore_missing_imports`, `warn_return_any=false`, ecc.)
- `github.py`: rimosse 6 `# type: ignore[union-attr]` legacy (non più necessarie)
- `mcp_server.py`: `result: dict` invece di dict inferito (5 errori `object.append`)
- `render.py`: rinominate variabili loop conflittuali (`s`/`di`/`ds` collisioni tra scope) + `None` guard su `sample_run`
- `tests/conftest.py`, `test_cli.py`: `workspace_root=None` esplicito

### Verifica
- `mypy src/ tests/` → Success: no issues found
- `pytest --cov-fail-under=70` → ✅ 80.33%