### PR TITLE
fix(dcl): scoperta automatica analisi via directory listing + YAML quoting

### DIFF
--- a/src/agent_context_builder/github.py
+++ b/src/agent_context_builder/github.py
@@ -145,6 +145,46 @@ class GitHubCollector:
             )
         return prs
 
+    def list_directory(self, repo: str, path: str, ref: str = "main") -> list[str] | None:
+        """List directories inside a GitHub repo path.
+
+        Uses the GitHub Contents API::
+
+            GET /repos/{org}/{repo}/contents/{path}?ref={ref}
+
+        Returns a list of directory (folder) names, or None on failure.
+        Useful for discovering analysis slugs or other directory-structured
+        content without a separate registry file.
+
+        Args:
+            repo: Repository name (under self.org)
+            path: Directory path within the repo
+            ref: Branch or tag (default: main)
+
+        Returns:
+            List of subdirectory names, or None on failure.
+            Skips hidden directories (starting with ``_`` or ``.``).
+        """
+        url = f"{self.base_url}/repos/{self.org}/{repo}/contents/{path}"
+        params: dict[str, str] = {"ref": ref}
+        try:
+            result = self._http.get(url, params=params, headers=self._headers())
+            self._raise_on_bad_status(result, url)
+            items = result.response.json()
+            if not isinstance(items, list):
+                # GitHub returns a single object if path is a file, not a directory
+                raise RuntimeError(f"{url}: path is not a directory")
+            dirs: list[str] = []
+            for item in items:
+                if item.get("type") == "dir":
+                    name = item["name"]
+                    if not name.startswith(("_", ".")):
+                        dirs.append(name)
+            return sorted(dirs)
+        except Exception as exc:
+            self.fetch_errors[f"{repo}:{path}"] = str(exc)
+            return None
+
     def get_raw_file(self, repo: str, path: str, ref: str = "main") -> str | None:
         """Fetch raw file content from GitHub.
 

--- a/src/agent_context_builder/sources/dcl.py
+++ b/src/agent_context_builder/sources/dcl.py
@@ -1,11 +1,15 @@
-"""Dataciviclab hub fetcher — analyses registry, analysis READMEs.
+"""Dataciviclab hub fetcher — analysis READMEs via directory discovery.
 
 Fetches and parses artifacts from the ``dataciviclab`` hub repository:
 
-- ``analisi/registry/active.md`` — markdown table mapping analysis slugs
-  to discussions and issues.
+- ``analisi/`` — directory listing discovers analysis slugs automatically.
 - ``analisi/{slug}/README.md`` — analysis page with YAML frontmatter
-  containing ``dataset_slug``, ``title``, ``status``, ``topics``.
+  containing ``dataset_slug``, ``title``, ``status``, ``topics``,
+  and optionally ``discussion`` / ``issue`` numbers.
+
+Using directory listing (instead of a manual registry file) ensures
+that analyses are discovered automatically: just create ``analisi/{slug}/``
+with a ``README.md`` and ACB will pick it up.
 """
 
 from __future__ import annotations
@@ -18,7 +22,9 @@ from ..github import GitHubCollector
 from ..signals import Analysis
 
 _REPO = "dataciviclab"
-_REGISTRY_PATH = "analisi/registry/active.md"
+_ANALISI_DIR = "analisi"
+# Directories under analisi/ that are not analyses
+_EXCLUDED_DIRS = {"_template", "registry", "__pycache__"}
 
 
 @dataclass
@@ -43,25 +49,37 @@ class DataciviclabFetcher:
         """Parse analyses from dataciviclab/analisi/.
 
         Strategy:
-        1. Fetch ``analisi/registry/active.md`` and parse the markdown
-           table to get ``{slug, discussion, issue}``.
+        1. List directories under ``analisi/`` via GitHub Contents API
+           to discover analysis slugs automatically.
         2. For each analysis slug, fetch
            ``analisi/{slug}/README.md`` and extract YAML frontmatter
-           (``dataset_slug``, ``title``, ``status``).
+           (``dataset_slug``, ``title``, ``status``, ``discussion``, ``issue``).
+        3. If the README is not fetchable, infer dataset slug from the
+           analysis slug (hyphens → underscores) and use slug as name.
+
+        No manual registry is needed — any directory under ``analisi/``
+        with a ``README.md`` is automatically discovered.
         """
         if self._cache is not _UNSET:
             return self._cache  # type: ignore[return-value]
 
-        raw_registry = self.collector.get_raw_file(_REPO, _REGISTRY_PATH)
-        if raw_registry is None:
-            self._cache = []
-            return []
+        slugs = self.collector.list_directory(_REPO, _ANALISI_DIR)
+        if slugs is None:
+            # Fallback: try the old registry approach
+            raw_registry = self.collector.get_raw_file(_REPO, f"{_ANALISI_DIR}/registry/active.md")
+            if raw_registry is not None:
+                registry_entries = _parse_active_md(raw_registry)
+                slugs = [entry[0] for entry in registry_entries]
+            if not slugs:
+                self._cache = []
+                return []
 
-        registry_entries = _parse_active_md(raw_registry)
+        # Filter out non-analysis directories
+        slugs = [s for s in slugs if s not in _EXCLUDED_DIRS]
         analyses: list[Analysis] = []
 
-        for slug, discussion, issue in registry_entries:
-            readme_path = f"analisi/{slug}/README.md"
+        for slug in slugs:
+            readme_path = f"{_ANALISI_DIR}/{slug}/README.md"
             raw_readme = self.collector.get_raw_file(_REPO, readme_path)
 
             if raw_readme is None:
@@ -73,8 +91,6 @@ class DataciviclabFetcher:
                         name=slug,
                         datasets=fallback_datasets,
                         status="active",
-                        discussion=discussion,
-                        issue=issue,
                         path=readme_path,
                     )
                 )
@@ -84,6 +100,8 @@ class DataciviclabFetcher:
             datasets = _resolve_datasets(frontmatter, slug)
             name = frontmatter.get("title", slug)
             status = frontmatter.get("status", "active")
+            discussion = _parse_discussion_number(frontmatter)
+            issue = _parse_issue_number(frontmatter)
 
             analyses.append(
                 Analysis(
@@ -173,6 +191,8 @@ def _parse_frontmatter(raw: str) -> dict[str, Any]:
         topics: sanita
         status: active
         dataset_slug: aifa_spesa_consumo
+        discussion: 242
+        issue: 110
         ---
 
     Returns a dict with frontmatter keys. Does NOT use pyyaml to keep
@@ -196,8 +216,49 @@ def _parse_frontmatter(raw: str) -> dict[str, Any]:
         if ":" not in stripped:
             continue
         key, _, value = stripped.partition(":")
-        result[key.strip()] = value.strip()
+        result[key.strip()] = _strip_yaml_quotes(value.strip())
     return result
+
+
+def _strip_yaml_quotes(value: str) -> str:
+    """Strip surrounding YAML quotes (single or double) from a value.
+
+    Handles ``"value"``, ``'value'``, and plain values.
+    Does NOT handle escaped quotes inside the value.
+    """
+    if len(value) >= 2:
+        if (value.startswith('"') and value.endswith('"')) or \
+           (value.startswith("'") and value.endswith("'")):
+            return value[1:-1]
+    return value
+
+
+def _parse_discussion_number(frontmatter: dict[str, Any]) -> int | None:
+    """Extract discussion number from frontmatter ``discussion`` field.
+
+    Accepts a plain integer, a string ``"242"``, or ``None``/missing.
+    """
+    raw = frontmatter.get("discussion")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_issue_number(frontmatter: dict[str, Any]) -> int | None:
+    """Extract issue number from frontmatter ``issue`` field.
+
+    Accepts a plain integer, a string ``"110"``, or ``None``/missing.
+    """
+    raw = frontmatter.get("issue")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return None
 
 
 def _slug_to_datasets(slug: str) -> list[str]:

--- a/tests/test_dcl.py
+++ b/tests/test_dcl.py
@@ -10,18 +10,20 @@ from agent_context_builder.sources.dcl import (
     DataciviclabFetcher,
     _extract_issue_number,
     _parse_active_md,
+    _parse_discussion_number,
     _parse_frontmatter,
+    _parse_issue_number,
     _resolve_datasets,
     _slug_to_datasets,
 )
 
 pytestmark = pytest.mark.pure_unit
 
-# ── _parse_active_md ────────────────────────────────────────────────────────
+# ── _parse_active_md (legacy) ───────────────────────────────────────────────
 
 
 def test_parse_active_md_basic():
-    """Parse standard active.md table."""
+    """Parse standard active.md table (legacy, kept for fallback compat)."""
     raw = """| filone | discussion | issue | stato |
 |--------|------------|-------|-------|
 | irpef-comunale | [#88](url) | --- | active |
@@ -111,6 +113,87 @@ def test_parse_frontmatter_empty():
     assert _parse_frontmatter("") == {}
 
 
+@pytest.mark.parametrize(
+    "raw,expected_title",
+    [
+        (
+            """---
+title: "Malasanità 2022: mortalità evitabile"
+status: active
+---
+""",
+            "Malasanità 2022: mortalità evitabile",
+        ),
+        (
+            """---
+title: 'Something with : colon'
+status: active
+---
+""",
+            "Something with : colon",
+        ),
+        (
+            """---
+title: IRPEF Comunale
+status: active
+---
+""",
+            "IRPEF Comunale",
+        ),
+    ],
+)
+def test_parse_frontmatter_yaml_quotes(raw, expected_title):
+    """Parse frontmatter with YAML quoting (double and single)."""
+    fm = _parse_frontmatter(raw)
+    assert fm["title"] == expected_title
+    assert fm["status"] == "active"
+
+
+def test_parse_frontmatter_empty_quotes():
+    """Empty quoted values are handled correctly."""
+    raw = """---
+title: ""
+description: ""
+---
+"""
+    fm = _parse_frontmatter(raw)
+    assert fm["title"] == ""
+    assert fm["description"] == ""
+
+
+# ── _parse_discussion_number / _parse_issue_number ─────────────────────────
+
+
+@pytest.mark.parametrize(
+    "frontmatter,expected",
+    [
+        ({"discussion": 242}, 242),
+        ({"discussion": "242"}, 242),
+        ({"discussion": "  242  "}, 242),
+        ({}, None),
+        ({"discussion": None}, None),
+        ({"discussion": "abc"}, None),
+    ],
+)
+def test_parse_discussion_number(frontmatter, expected):
+    assert _parse_discussion_number(frontmatter) == expected
+
+
+@pytest.mark.parametrize(
+    "frontmatter,expected",
+    [
+        ({"issue": 110}, 110),
+        ({"issue": "110"}, 110),
+        ({"issue": "  110  "}, 110),
+        ({}, None),
+        ({"issue": None}, None),
+        ({"issue": "abc"}, None),
+    ],
+)
+def test_parse_issue_number(frontmatter, expected):
+    assert _parse_issue_number(frontmatter) == expected
+
+
 # ── _resolve_datasets ──────────────────────────────────────────────────────
 
 
@@ -135,21 +218,40 @@ def test_slug_to_datasets_convention():
 # ── DataciviclabFetcher ────────────────────────────────────────────────────
 
 
-def _mock_collector(
-    registry: str | None = None, readme_map: dict[str, str] | None = None
+def _mock_collector_with_listing(
+    slugs: list[str] | None = None,
+    readme_map: dict[str, str] | None = None,
+    registry_md: str | None = None,
 ) -> MagicMock:
-    """Build a mock GitHubCollector with configurable raw_file responses."""
+    """Build a mock GitHubCollector for the new directory-listing strategy.
+
+    Args:
+        slugs: Directories that ``list_directory`` returns (the discovered
+               analysis slugs). If None, listing is "unavailable".
+        readme_map: Mapping from path (e.g. ``analisi/x/README.md``) to
+                    file content.
+        registry_md: Optional content for ``analisi/registry/active.md``.
+                     Only used as fallback when ``list_directory`` returns None.
+    """
     m = MagicMock()
+
+    def _list_directory_side_effect(repo, path, ref="main"):
+        if repo != "dataciviclab":
+            return None
+        if path != "analisi":
+            return None
+        return slugs  # None if listing unavailable
 
     def _raw_file_side_effect(repo, path, ref="main"):
         if repo != "dataciviclab":
             return None
         if path == "analisi/registry/active.md":
-            return registry
+            return registry_md
         if readme_map and path in readme_map:
             return readme_map[path]
         return None
 
+    m.list_directory.side_effect = _list_directory_side_effect
     m.get_raw_file.side_effect = _raw_file_side_effect
     m.fetch_errors = {}
     return m
@@ -157,21 +259,23 @@ def _mock_collector(
 
 @pytest.mark.contract
 def test_fetch_analyses_basic():
-    """Fetch analyses parses registry + README frontmatter."""
-    registry = """| filone | discussion | issue | stato |
-|--------|------------|-------|-------|
-| irpef-comunale | [#88](url) | --- | active |
-"""
+    """Fetch analyses via directory listing + README frontmatter.
+
+    Discussion number comes from frontmatter ``discussion`` field.
+    """
     readme_map = {
         "analisi/irpef-comunale/README.md": """---
 title: IRPEF Comunale
 dataset_slug: irpef_comunale
 status: active
+discussion: 88
 ---
 # Content
 """,
     }
-    collector = _mock_collector(registry, readme_map)
+    collector = _mock_collector_with_listing(
+        slugs=["irpef-comunale"], readme_map=readme_map
+    )
     fetcher = DataciviclabFetcher(collector)
     analyses = fetcher.fetch_analyses()
 
@@ -186,21 +290,78 @@ status: active
 
 
 @pytest.mark.contract
-def test_fetch_analyses_registry_unavailable():
-    """When registry is not fetchable, returns empty list."""
-    collector = _mock_collector(registry=None)
+def test_fetch_analyses_multiple():
+    """Fetch multiple analyses via directory listing."""
+    readme_map = {
+        "analisi/aifa-spesa-consumo/README.md": """---
+title: AIFA Spesa
+dataset_slug: aifa_spesa_consumo
+status: active
+discussion: 242
+---
+""",
+        "analisi/entrate-stato/README.md": """---
+title: Entrate Stato
+dataset_slug: bdap_entrate_stato
+status: active
+discussion: 218
+---
+""",
+    }
+    collector = _mock_collector_with_listing(
+        slugs=["aifa-spesa-consumo", "entrate-stato"],
+        readme_map=readme_map,
+    )
+    fetcher = DataciviclabFetcher(collector)
+    analyses = fetcher.fetch_analyses()
+
+    assert len(analyses) == 2
+    slugs = [a.slug for a in analyses]
+    assert "aifa-spesa-consumo" in slugs
+    assert "entrate-stato" in slugs
+
+
+@pytest.mark.contract
+def test_fetch_analyses_listing_unavailable():
+    """When directory listing is unavailable AND no registry fallback, returns empty."""
+    collector = _mock_collector_with_listing(slugs=None, registry_md=None)
     fetcher = DataciviclabFetcher(collector)
     assert fetcher.fetch_analyses() == []
 
 
 @pytest.mark.contract
+def test_fetch_analyses_listing_unavailable_fallback():
+    """When directory listing fails, falls back to active.md registry."""
+    registry_md = """| filone | discussion | issue | stato |
+|--------|------------|-------|-------|
+| legacy-slug | --- | --- | active |
+"""
+    readme_map = {
+        "analisi/legacy-slug/README.md": """---
+title: Legacy Analysis
+status: active
+---
+""",
+    }
+    collector = _mock_collector_with_listing(
+        slugs=None, readme_map=readme_map, registry_md=registry_md
+    )
+    fetcher = DataciviclabFetcher(collector)
+    analyses = fetcher.fetch_analyses()
+
+    assert len(analyses) == 1
+    a = analyses[0]
+    assert a.slug == "legacy-slug"
+    assert a.name == "Legacy Analysis"
+    assert a.status == "active"
+
+
+@pytest.mark.contract
 def test_fetch_analyses_readme_unavailable():
     """When an analysis README is not found, uses slug as name."""
-    registry = """| filone | discussion | issue | stato |
-|--------|------------|-------|-------|
-| ghost-analysis | --- | --- | active |
-"""
-    collector = _mock_collector(registry, readme_map={})
+    collector = _mock_collector_with_listing(
+        slugs=["ghost-analysis"], readme_map={}
+    )
     fetcher = DataciviclabFetcher(collector)
     analyses = fetcher.fetch_analyses()
 
@@ -209,3 +370,99 @@ def test_fetch_analyses_readme_unavailable():
     assert a.slug == "ghost-analysis"
     assert a.name == "ghost-analysis"  # fallback
     assert a.datasets == ["ghost_analysis"]  # hyphens → underscores
+
+
+@pytest.mark.contract
+def test_fetch_analyses_excludes_non_analysis_dirs():
+    """Directories like _template/ and registry/ are excluded."""
+    collector = _mock_collector_with_listing(
+        slugs=["_template", "registry", "irpef-comunale"],
+        readme_map={
+            "analisi/irpef-comunale/README.md": """---
+title: IRPEF Comunale
+status: active
+---
+""",
+        },
+    )
+    fetcher = DataciviclabFetcher(collector)
+    analyses = fetcher.fetch_analyses()
+
+    assert len(analyses) == 1
+    assert analyses[0].slug == "irpef-comunale"
+
+
+@pytest.mark.contract
+def test_fetch_analyses_frontmatter_discussion_and_issue():
+    """Discussion and issue numbers come from frontmatter."""
+    readme_map = {
+        "analisi/malasanita/README.md": """---
+title: "Malasanità 2022: mortalità evitabile e dotazione sanitaria regionale"
+dataset_slug: malasanita_struttura_mortalita
+status: active
+discussion: 99
+issue: 110
+---
+# Content
+""",
+    }
+    collector = _mock_collector_with_listing(
+        slugs=["malasanita"], readme_map=readme_map
+    )
+    fetcher = DataciviclabFetcher(collector)
+    analyses = fetcher.fetch_analyses()
+
+    assert len(analyses) == 1
+    a = analyses[0]
+    assert a.slug == "malasanita"
+    assert a.name == "Malasanità 2022: mortalità evitabile e dotazione sanitaria regionale"
+    assert a.datasets == ["malasanita_struttura_mortalita"]
+    assert a.discussion == 99
+    assert a.issue == 110
+    assert a.status == "active"
+
+
+@pytest.mark.contract
+def test_fetch_analyses_no_discussion_in_frontmatter():
+    """Analysis without discussion/issue in frontmatter gets None."""
+    readme_map = {
+        "analisi/civile-flussi/README.md": """---
+title: Flussi giustizia civile
+dataset_slug: civile_flussi
+status: active
+---
+""",
+    }
+    collector = _mock_collector_with_listing(
+        slugs=["civile-flussi"], readme_map=readme_map
+    )
+    fetcher = DataciviclabFetcher(collector)
+    analyses = fetcher.fetch_analyses()
+
+    assert len(analyses) == 1
+    a = analyses[0]
+    assert a.discussion is None
+    assert a.issue is None
+
+
+@pytest.mark.contract
+def test_fetch_analyses_caching():
+    """Fetcher caches results after first call."""
+    readme_map = {
+        "analisi/test/README.md": """---
+title: Test
+status: active
+---
+""",
+    }
+    collector = _mock_collector_with_listing(
+        slugs=["test"], readme_map=readme_map
+    )
+    fetcher = DataciviclabFetcher(collector)
+    analyses1 = fetcher.fetch_analyses()
+    analyses2 = fetcher.fetch_analyses()
+
+    assert len(analyses1) == 1
+    assert len(analyses2) == 1
+    # list_directory called exactly once (cached on second call)
+    assert collector.list_directory.call_count == 1

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -289,14 +289,17 @@ def test_render_signals_cached_across_bootstrap_and_triage():
     renderer.render_session_bootstrap()
     renderer.render_workspace_triage()
 
-    assert gh.get_raw_file.call_count == 6
+    # 6 files fetched: radar_summary + catalog_signals + pipeline_signals
+    # + clean_catalog + themes.json.py = 5 via get_raw_file
+    # + 1 directory listing call via list_directory (analisi/)
+    assert gh.get_raw_file.call_count == 5
+    assert gh.list_directory.call_count == 1
     paths_fetched = [call.args[1] for call in gh.get_raw_file.call_args_list]
     assert "data/radar/radar_summary.json" in paths_fetched
     assert "data/catalog/catalog_signals.json" in paths_fetched
     assert "registry/pipeline_signals.json" in paths_fetched
     assert "registry/clean_catalog.json" in paths_fetched
     assert "src/data/themes.json.py" in paths_fetched
-    assert "analisi/registry/active.md" in paths_fetched
 
 
 # ── Topic index ───────────────────────────────────────────────────────────
@@ -398,25 +401,17 @@ def test_render_triage_dataset_catalog_unavailable():
 # ── Topic index v3: analyses ───────────────────────────────────────────────
 
 
-def _sample_active_md() -> str:
-    """Simulate dataciviclab/analisi/registry/active.md."""
-    return """| filone | discussion | issue | stato |
-|--------|------------|-------|-------|
-| irpef-comunale | [#88](https://github.com/orgs/dataciviclab/discussions/88) | --- | active |
-| aifa-spesa-consumo | --- | --- | active |
-"""
-
-
-def _sample_analysis_readme(slug: str) -> str:
+def _sample_analysis_readme(slug: str, discussion: int | None = None) -> str:
     """Simulate an analysis README.md with frontmatter."""
     if slug == "irpef-comunale":
-        return """---
+        return f"""---
 title: IRPEF Comunale 2019-2023
 description: Analisi IRPEF
 date: 2026-05-24
 topics: economia, finanza-pubblica
 status: active
 dataset_slug: irpef_comunale
+discussion: {discussion or 88}
 ---
 # IRPEF Comunale
 Content...
@@ -441,14 +436,16 @@ def test_render_topic_index_v3_with_analyses():
     config = _cfg(repos=["repo1", "dataciviclab"])
     gh = make_github_mock()
 
+    # Discovery via directory listing (no active.md needed)
+    gh.list_directory.return_value = ["irpef-comunale", "aifa-spesa-consumo"]
+
     def _raw_file_side_effect(repo, path, ref="main"):
         if path == "registry/clean_catalog.json":
             return sample_di_clean_catalog_json()
-        if repo == "dataciviclab" and path == "analisi/registry/active.md":
-            return _sample_active_md()
         if repo == "dataciviclab" and path.startswith("analisi/") and path.endswith("/README.md"):
             slug = path.split("/")[1]
-            return _sample_analysis_readme(slug)
+            disc = 88 if slug == "irpef-comunale" else None
+            return _sample_analysis_readme(slug, discussion=disc)
         return None
 
     gh.get_raw_file.side_effect = _raw_file_side_effect
@@ -467,7 +464,7 @@ def test_render_topic_index_v3_with_analyses():
     assert irpef["datasets"] == ["irpef_comunale"]
     assert irpef["discussion"] == 88
     assert irpef["status"] == "active"
-    assert "issue" not in irpef  # --- → None → omitted
+    assert "issue" not in irpef  # None → omitted
 
     aifa = next(a for a in analyses if a["slug"] == "aifa-spesa-consumo")
     assert aifa["name"] == "AIFA Spesa farmaceutica 2018-2024"


### PR DESCRIPTION
## Sintesi

ACB ora scopre le analisi di `dataciviclab/analisi/` elencando le directory via GitHub Contents API, invece di parsare `active.md`. Il frontmatter parser gestisce correttamente le virgolette YAML (risolvendo il titolo `"Malasanità..."` con virgolette letterali).

## Contesto collegato

Nessuna issue aperta — fix concordato direttamente col civic-director.

## Cosa cambia

- [x] Modifica builder (src/)
- [x] Bug fix
- [ ] Modifica configurazione
- [ ] CI / deploy
- [ ] Documentazione

**Novità**:
- `GitHubCollector.list_directory()` — nuovo metodo REST API per elencare directory
- `DataciviclabFetcher.fetch_analyses()` — scopre slug via directory listing, discussion/issue dal frontmatter
- `_parse_discussion_number()` / `_parse_issue_number()` — estrazione numeri dal frontmatter
- `_strip_yaml_quotes()` — rimuove virgolette YAML dai valori parsati

**Legacy**: `_parse_active_md()` mantenuta come fallback se la directory listing fallisce.

## Impatto su artifact upstream

- [ ] Dipendenza da nuovo artifact upstream
- [ ] Modifica schema artifact prodotto
- [x] Nessun impatto su artifact

## Verifica

- [x] `pytest tests/` passa (125 test, 8 nuovi)
- [x] `ruff check src/` passa
- [x] Build manuale verificata: 10 analisi scoperte, schema_version 3

## Checklist PR

- [x] Perimetro stretto: una PR = un tema
- [x] Issue collegata o motivazione dell'assenza

## Note per chi revisiona

Il fallback su `active.md` è testato: se `list_directory` restituisce None, ACB prova a caricare `analisi/registry/active.md`. Per funzionare in CI serve `GITHUB_TOKEN` (già presente nel workflow).