### PR TITLE
chore: pre-commit hooks (ruff + ruff-format) + editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/scripts/audit_test_markers.py
+++ b/.github/scripts/audit_test_markers.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python3
 """Backward-compatibility shim — delegates to ``lab_connectors.testing.audit_markers``."""
+
 import sys
+
 try:
     from lab_connectors.testing.audit_markers import main
 except ImportError:
-    print("ERROR: lab-connectors not installed.\n\nInstall: pip install lab-connectors", file=sys.stderr)
+    print(
+        "ERROR: lab-connectors not installed.\n\nInstall: pip install lab-connectors",
+        file=sys.stderr,
+    )
     sys.exit(2)
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# Pre-commit hooks per agent-context-builder.
+# Installare con: pre-commit install
+# Run su tutti i file: pre-commit run --all-files
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: detect-private-key
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.16
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/src/agent_context_builder/cli.py
+++ b/src/agent_context_builder/cli.py
@@ -88,7 +88,9 @@ def build(
 
     click.echo("Creating renderer")
     renderer = Renderer(
-        cfg, github_collector, git_collector,
+        cfg,
+        github_collector,
+        git_collector,
         discussion_collector=discussion_collector,
         fixed_timestamp=generated_at,
     )

--- a/src/agent_context_builder/config.py
+++ b/src/agent_context_builder/config.py
@@ -27,9 +27,7 @@ class Config(BaseModel):
         description="Root of local workspace — set via --workspace-root or DATACIVICLAB_WORKSPACE",
     )
     github_org: str = Field(..., description="GitHub organization")
-    repos: list[str] = Field(
-        default_factory=list, description="Primary repos to monitor"
-    )
+    repos: list[str] = Field(default_factory=list, description="Primary repos to monitor")
     topics: dict[str, Topic] = Field(default_factory=dict, description="Topic index")
 
     @classmethod

--- a/src/agent_context_builder/discussions.py
+++ b/src/agent_context_builder/discussions.py
@@ -41,8 +41,9 @@ class Discussion:
 class DiscussionCollector:
     """Collect open discussions from GitHub via GraphQL."""
 
-    def __init__(self, org: str, token: Optional[str] = None,
-                 http_client: Optional[HttpClient] = None):
+    def __init__(
+        self, org: str, token: Optional[str] = None, http_client: Optional[HttpClient] = None
+    ):
         """Initialize discussion collector.
 
         Args:
@@ -95,10 +96,7 @@ class DiscussionCollector:
             raise ValueError(f"GraphQL errors: {payload['errors']}")
 
         nodes = (
-            payload.get("data", {})
-            .get("repository", {})
-            .get("discussions", {})
-            .get("nodes", [])
+            payload.get("data", {}).get("repository", {}).get("discussions", {}).get("nodes", [])
         )
         return [
             Discussion(

--- a/src/agent_context_builder/github.py
+++ b/src/agent_context_builder/github.py
@@ -43,8 +43,9 @@ class RepoInfo:
 class GitHubCollector:
     """Collect context from GitHub API."""
 
-    def __init__(self, org: str, token: Optional[str] = None,
-                 http_client: Optional[HttpClient] = None):
+    def __init__(
+        self, org: str, token: Optional[str] = None, http_client: Optional[HttpClient] = None
+    ):
         """Initialize GitHub collector.
 
         Args:
@@ -254,10 +255,7 @@ class GitHubCollector:
             or None if no runs found or on error.
         """
         if workflow_id:
-            url = (
-                f"{self.base_url}/repos/{self.org}/{repo}"
-                f"/actions/workflows/{workflow_id}/runs"
-            )
+            url = f"{self.base_url}/repos/{self.org}/{repo}/actions/workflows/{workflow_id}/runs"
         else:
             url = f"{self.base_url}/repos/{self.org}/{repo}/actions/runs"
         params = {

--- a/src/agent_context_builder/render.py
+++ b/src/agent_context_builder/render.py
@@ -88,10 +88,7 @@ class Renderer:
                     lines.append(f"  ⚠ **{radar.persistent_red} persistent RED**")
                 if radar.unhealthy:
                     for rs in radar.unhealthy:
-                        _d = (
-                            f" — ↳ {', '.join(rs.datasets_in_use)}"
-                            if rs.datasets_in_use else ""
-                        )
+                        _d = f" — ↳ {', '.join(rs.datasets_in_use)}" if rs.datasets_in_use else ""
                         streak = f" (streak {rs.red_streak})" if rs.red_streak else ""
                         note = f" — {rs.note}" if rs.note else ""
                         _row = f"  · **{rs.id}** {rs.status} [{rs.http_code}]{note}{streak}{_d}"

--- a/src/agent_context_builder/sources/dcl.py
+++ b/src/agent_context_builder/sources/dcl.py
@@ -227,8 +227,9 @@ def _strip_yaml_quotes(value: str) -> str:
     Does NOT handle escaped quotes inside the value.
     """
     if len(value) >= 2:
-        if (value.startswith('"') and value.endswith('"')) or \
-           (value.startswith("'") and value.endswith("'")):
+        if (value.startswith('"') and value.endswith('"')) or (
+            value.startswith("'") and value.endswith("'")
+        ):
             return value[1:-1]
     return value
 

--- a/src/agent_context_builder/sources/di.py
+++ b/src/agent_context_builder/sources/di.py
@@ -67,4 +67,3 @@ class _Unset:
 
 
 _UNSET = _Unset()
-

--- a/src/agent_context_builder/sources/so.py
+++ b/src/agent_context_builder/sources/so.py
@@ -72,4 +72,3 @@ class _Unset:
 
 
 _UNSET = _Unset()
-

--- a/src/agent_context_builder/triage.py
+++ b/src/agent_context_builder/triage.py
@@ -212,10 +212,9 @@ def _build_dataset_catalog_dict(
                 "metric_columns": d.metric_columns,
                 "dimension_columns": d.dimension_columns,
                 "column_count": d.column_count,
-                "columns": [
-                    {"name": c.name, "role": c.role}
-                    for c in d.columns
-                ] if d.stage == "published" else [],
+                "columns": [{"name": c.name, "role": c.role} for c in d.columns]
+                if d.stage == "published"
+                else [],
             }
             for d in catalog.datasets
         ],
@@ -266,8 +265,7 @@ def _build_explorer_dict(
     return {
         "available": True,
         "themes": [
-            {"slug": t.slug, "name": t.name, "dataset_count": len(t.datasets)}
-            for t in themes
+            {"slug": t.slug, "name": t.name, "dataset_count": len(t.datasets)} for t in themes
         ],
         "published_count": len(themed_slugs),
         "clean_ready_not_published": clean_ready_not_published,
@@ -281,8 +279,7 @@ def _collect_warnings(
     repos_state: dict[str, GitState],
 ) -> list[str]:
     warnings = [
-        f"GitHub fetch failed — {key}: {err}"
-        for key, err in github_collector.fetch_errors.items()
+        f"GitHub fetch failed — {key}: {err}" for key, err in github_collector.fetch_errors.items()
     ]
     if len(prs) > 5:
         warnings.append(f"Many open PRs: {len(prs)}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ fixtures for config, git state, and mock collectors.
 Factory functions and sample data for render tests are also defined here —
 they are importable from conftest (``from tests.conftest import ...``).
 """
+
 from __future__ import annotations
 
 import json
@@ -113,7 +114,11 @@ def mock_git_collector():
 
 
 def make_github_mock(
-    prs=None, issues=None, fetch_errors=None, raw_file=None, repos_info=None,
+    prs=None,
+    issues=None,
+    fetch_errors=None,
+    raw_file=None,
+    repos_info=None,
 ):
     """Build a ``MagicMock(spec=GitHubCollector)`` with configured returns.
 
@@ -135,8 +140,7 @@ def make_github_mock(
             )
         else:
             m.collector_warning.return_value = (
-                f"GitHub fetch error ({len(errors)} collector(s) affected) "
-                "- data may be incomplete"
+                f"GitHub fetch error ({len(errors)} collector(s) affected) - data may be incomplete"
             )
     else:
         m.collector_warning.return_value = None
@@ -159,63 +163,86 @@ def sample_so_json(drift: bool = False) -> str:
     """Simulate ``catalog_signals.json`` from source-observatory."""
     signals = []
     if drift:
-        signals.append({
-            "source": "inps", "protocol": "ckan",
-            "signal_type": "inventory change", "result": "inventory change",
-            "detail": "Delta inventario +8 rispetto alla baseline.",
-            "suggested_action": "verificare se variazione attesa",
-        })
-    signals.append({
-        "source": "istat_sdmx", "protocol": "sdmx",
-        "signal_type": "no signal", "result": "stabile",
-        "detail": "ok", "suggested_action": "nessuna",
-    })
-    return json.dumps({
-        "captured_at": "2026-04-12", "sources_checked": len(signals), "signals": signals,
-    })
+        signals.append(
+            {
+                "source": "inps",
+                "protocol": "ckan",
+                "signal_type": "inventory change",
+                "result": "inventory change",
+                "detail": "Delta inventario +8 rispetto alla baseline.",
+                "suggested_action": "verificare se variazione attesa",
+            }
+        )
+    signals.append(
+        {
+            "source": "istat_sdmx",
+            "protocol": "sdmx",
+            "signal_type": "no signal",
+            "result": "stabile",
+            "detail": "ok",
+            "suggested_action": "nessuna",
+        }
+    )
+    return json.dumps(
+        {
+            "captured_at": "2026-04-12",
+            "sources_checked": len(signals),
+            "signals": signals,
+        }
+    )
 
 
 def sample_di_json() -> str:
     """Simulate ``pipeline_signals.json`` from dataset-incubator."""
-    return json.dumps({
-        "schema_version": "1",
-        "generated_at": "2026-04-16T10:00:00",
-        "repo": "dataciviclab/dataset-incubator",
-        "topic": "pipeline_state",
-        "signals": [
-            {
-                "id": "irpef-comunale", "status": "ok",
-                "label": "irpef-comunale", "detail": "", "action": "",
-            },
-        ],
-        "summary": {"ok": 1, "warn": 0, "error": 0},
-    })
+    return json.dumps(
+        {
+            "schema_version": "1",
+            "generated_at": "2026-04-16T10:00:00",
+            "repo": "dataciviclab/dataset-incubator",
+            "topic": "pipeline_state",
+            "signals": [
+                {
+                    "id": "irpef-comunale",
+                    "status": "ok",
+                    "label": "irpef-comunale",
+                    "detail": "",
+                    "action": "",
+                },
+            ],
+            "summary": {"ok": 1, "warn": 0, "error": 0},
+        }
+    )
 
 
 def sample_di_clean_catalog_json() -> str:
     """Simulate ``clean_catalog.json`` from dataset-incubator."""
-    return json.dumps({
-        "schema_version": 1,
-        "name": "Lab Clean Registry",
-        "updated_at": "2026-04-14",
-        "datasets": [
-            {
-                "slug": "irpef_comunale",
-                "name": "IRPEF Comunale",
-                "stage": "published",
-                "period": {"start": 2022, "end": 2023},
-                "location": {"type": "gcs", "path": "gs://dataciviclab-clean/irpef/irpef.parquet"},
-                "columns": [
-                    {"name": "anno", "role": "dimension"},
-                    {"name": "comune", "role": "dimension"},
-                    {"name": "imposta", "role": "metric"},
-                ],
-            },
-            {
-                "slug": "draft_dataset",
-                "name": "Draft Dataset",
-                "stage": "incubating",
-                "columns": [],
-            },
-        ],
-    })
+    return json.dumps(
+        {
+            "schema_version": 1,
+            "name": "Lab Clean Registry",
+            "updated_at": "2026-04-14",
+            "datasets": [
+                {
+                    "slug": "irpef_comunale",
+                    "name": "IRPEF Comunale",
+                    "stage": "published",
+                    "period": {"start": 2022, "end": 2023},
+                    "location": {
+                        "type": "gcs",
+                        "path": "gs://dataciviclab-clean/irpef/irpef.parquet",
+                    },
+                    "columns": [
+                        {"name": "anno", "role": "dimension"},
+                        {"name": "comune", "role": "dimension"},
+                        {"name": "imposta", "role": "metric"},
+                    ],
+                },
+                {
+                    "slug": "draft_dataset",
+                    "name": "Draft Dataset",
+                    "stage": "incubating",
+                    "columns": [],
+                },
+            ],
+        }
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 """Tests for the CLI entry point (``cli.py``)."""
+
 from __future__ import annotations
 
 import json
@@ -29,13 +30,20 @@ def _mock_renderer():
     m = MagicMock()
     m.render_session_bootstrap.return_value = "# Session Bootstrap\n"
     m.render_workspace_triage.return_value = {
-        "open_prs": 0, "open_issues": 0, "open_discussions": 0,
-        "warnings": [], "github_fetch_errors": {}, "git_state": {},
+        "open_prs": 0,
+        "open_issues": 0,
+        "open_discussions": 0,
+        "warnings": [],
+        "github_fetch_errors": {},
+        "git_state": {},
         "source_health": {"available": False},
-        "dataset_catalog": {"available": False}, "discussions": [],
+        "dataset_catalog": {"available": False},
+        "discussions": [],
     }
     m.render_topic_index.return_value = {
-        "repos": {}, "datasets_by_source": {}, "operational_topics": {},
+        "repos": {},
+        "datasets_by_source": {},
+        "operational_topics": {},
     }
     return m
 
@@ -53,11 +61,16 @@ def test_build_creates_three_artifacts(tmp_path: Path):
     ):
         rdr_cls.return_value = _mock_renderer()
         runner = CliRunner()
-        result = runner.invoke(cli, [
-            "build",
-            "--config", str(config_path),
-            "--out", str(out),
-        ])
+        result = runner.invoke(
+            cli,
+            [
+                "build",
+                "--config",
+                str(config_path),
+                "--out",
+                str(out),
+            ],
+        )
 
     assert result.exit_code == 0, result.output
     assert (out / "session_bootstrap.md").exists()
@@ -81,11 +94,16 @@ def test_build_without_token_skips_discussions(tmp_path: Path):
     ):
         rdr_cls.return_value = _mock_renderer()
         runner = CliRunner()
-        result = runner.invoke(cli, [
-            "build",
-            "--config", str(config_path),
-            "--out", str(out),
-        ])
+        result = runner.invoke(
+            cli,
+            [
+                "build",
+                "--config",
+                str(config_path),
+                "--out",
+                str(out),
+            ],
+        )
 
     assert result.exit_code == 0, result.output
     assert "discussions skipped" in result.output
@@ -110,12 +128,18 @@ def test_build_with_token_passes_to_collectors(tmp_path: Path):
         rdr_cls.return_value = _mock_renderer()
 
         runner = CliRunner()
-        result = runner.invoke(cli, [
-            "build",
-            "--config", str(config_path),
-            "--out", str(out),
-            "--github-token", "my-token",
-        ])
+        result = runner.invoke(
+            cli,
+            [
+                "build",
+                "--config",
+                str(config_path),
+                "--out",
+                str(out),
+                "--github-token",
+                "my-token",
+            ],
+        )
 
     assert result.exit_code == 0, result.output
     gh_cls.assert_called_once_with("test-org", token="my-token")
@@ -137,12 +161,18 @@ def test_build_with_generated_at_produces_deterministic_output(tmp_path: Path):
     ):
         rdr_cls.return_value = _mock_renderer()
         runner = CliRunner()
-        result = runner.invoke(cli, [
-            "build",
-            "--config", str(config_path),
-            "--out", str(out),
-            "--generated-at", "2026-01-15T00:00:00Z",
-        ])
+        result = runner.invoke(
+            cli,
+            [
+                "build",
+                "--config",
+                str(config_path),
+                "--out",
+                str(out),
+                "--generated-at",
+                "2026-01-15T00:00:00Z",
+            ],
+        )
 
     assert result.exit_code == 0, result.output
     _, kwargs = rdr_cls.call_args
@@ -165,12 +195,18 @@ def test_build_with_workspace_root_overrides_config(tmp_path: Path):
         rdr_cls.return_value = _mock_renderer()
 
         runner = CliRunner()
-        result = runner.invoke(cli, [
-            "build",
-            "--config", str(config_path),
-            "--out", str(out),
-            "--workspace-root", str(ws_root),
-        ])
+        result = runner.invoke(
+            cli,
+            [
+                "build",
+                "--config",
+                str(config_path),
+                "--out",
+                str(out),
+                "--workspace-root",
+                str(ws_root),
+            ],
+        )
 
     assert result.exit_code == 0, result.output
     assert "my_workspace" in result.output
@@ -182,10 +218,15 @@ def test_build_with_workspace_root_overrides_config(tmp_path: Path):
 def test_build_fails_on_missing_config(tmp_path: Path):
     """Non-existent --config path → Click error."""
     runner = CliRunner()
-    result = runner.invoke(cli, [
-        "build",
-        "--config", str(tmp_path / "nonexistent.yml"),
-        "--out", str(tmp_path / "out"),
-    ])
+    result = runner.invoke(
+        cli,
+        [
+            "build",
+            "--config",
+            str(tmp_path / "nonexistent.yml"),
+            "--out",
+            str(tmp_path / "out"),
+        ],
+    )
     assert result.exit_code != 0
     assert "does not exist" in result.output

--- a/tests/test_dcl.py
+++ b/tests/test_dcl.py
@@ -273,9 +273,7 @@ discussion: 88
 # Content
 """,
     }
-    collector = _mock_collector_with_listing(
-        slugs=["irpef-comunale"], readme_map=readme_map
-    )
+    collector = _mock_collector_with_listing(slugs=["irpef-comunale"], readme_map=readme_map)
     fetcher = DataciviclabFetcher(collector)
     analyses = fetcher.fetch_analyses()
 
@@ -359,9 +357,7 @@ status: active
 @pytest.mark.contract
 def test_fetch_analyses_readme_unavailable():
     """When an analysis README is not found, uses slug as name."""
-    collector = _mock_collector_with_listing(
-        slugs=["ghost-analysis"], readme_map={}
-    )
+    collector = _mock_collector_with_listing(slugs=["ghost-analysis"], readme_map={})
     fetcher = DataciviclabFetcher(collector)
     analyses = fetcher.fetch_analyses()
 
@@ -406,9 +402,7 @@ issue: 110
 # Content
 """,
     }
-    collector = _mock_collector_with_listing(
-        slugs=["malasanita"], readme_map=readme_map
-    )
+    collector = _mock_collector_with_listing(slugs=["malasanita"], readme_map=readme_map)
     fetcher = DataciviclabFetcher(collector)
     analyses = fetcher.fetch_analyses()
 
@@ -433,9 +427,7 @@ status: active
 ---
 """,
     }
-    collector = _mock_collector_with_listing(
-        slugs=["civile-flussi"], readme_map=readme_map
-    )
+    collector = _mock_collector_with_listing(slugs=["civile-flussi"], readme_map=readme_map)
     fetcher = DataciviclabFetcher(collector)
     analyses = fetcher.fetch_analyses()
 
@@ -455,9 +447,7 @@ status: active
 ---
 """,
     }
-    collector = _mock_collector_with_listing(
-        slugs=["test"], readme_map=readme_map
-    )
+    collector = _mock_collector_with_listing(slugs=["test"], readme_map=readme_map)
     fetcher = DataciviclabFetcher(collector)
     analyses1 = fetcher.fetch_analyses()
     analyses2 = fetcher.fetch_analyses()

--- a/tests/test_discussions.py
+++ b/tests/test_discussions.py
@@ -1,4 +1,5 @@
 """Tests for discussions module — uses FakeHttpClient for HTTP boundary."""
+
 from __future__ import annotations
 
 import pytest
@@ -14,9 +15,13 @@ _GRAPHQL_URL = "https://api.github.com/graphql"
 def test_discussion_creation():
     """Discussion dataclass holds expected fields."""
     d = Discussion(
-        number=1, title="Analisi IRPEF", repo="dataset-incubator",
+        number=1,
+        title="Analisi IRPEF",
+        repo="dataset-incubator",
         url="https://github.com/dataciviclab/dataset-incubator/discussions/1",
-        category="Civic Questions", author="gabry", updated_at="2026-04-14T20:00:00Z",
+        category="Civic Questions",
+        author="gabry",
+        updated_at="2026-04-14T20:00:00Z",
     )
     assert d.number == 1
     assert d.category == "Civic Questions"
@@ -25,8 +30,7 @@ def test_discussion_creation():
 @pytest.mark.adapter
 def test_get_discussions_no_token():
     """Without token, all repos fail with ValueError recorded in fetch_errors."""
-    collector = DiscussionCollector(org="dataciviclab", token=None,
-                                    http_client=None)
+    collector = DiscussionCollector(org="dataciviclab", token=None, http_client=None)
     results = collector.get_discussions(["dataset-incubator"])
 
     assert results == []
@@ -41,8 +45,7 @@ def test_get_discussions_api_error(fake_http):
         response=fake_response(403, text="Forbidden"),
         err=None,
     )
-    collector = DiscussionCollector(org="dataciviclab", token="fake-token",
-                                    http_client=fake_http)
+    collector = DiscussionCollector(org="dataciviclab", token="fake-token", http_client=fake_http)
 
     results = collector.get_discussions(["dataset-incubator"])
 
@@ -54,28 +57,30 @@ def test_get_discussions_api_error(fake_http):
 def test_get_discussions_success(fake_http):
     """Successful GraphQL response is parsed into Discussion objects."""
     fake_http.responses[_GRAPHQL_URL] = HttpResult(
-        response=fake_response(200, json_data={
-            "data": {
-                "repository": {
-                    "discussions": {
-                        "nodes": [
-                            {
-                                "number": 42,
-                                "title": "IRPEF comunale: cosa ci dice?",
-                                "url": "https://github.com/dataciviclab/dataset-incubator/discussions/42",
-                                "category": {"name": "Civic Questions"},
-                                "author": {"login": "gabry"},
-                                "updatedAt": "2026-04-14T20:00:00Z",
-                            }
-                        ]
+        response=fake_response(
+            200,
+            json_data={
+                "data": {
+                    "repository": {
+                        "discussions": {
+                            "nodes": [
+                                {
+                                    "number": 42,
+                                    "title": "IRPEF comunale: cosa ci dice?",
+                                    "url": "https://github.com/dataciviclab/dataset-incubator/discussions/42",
+                                    "category": {"name": "Civic Questions"},
+                                    "author": {"login": "gabry"},
+                                    "updatedAt": "2026-04-14T20:00:00Z",
+                                }
+                            ]
+                        }
                     }
                 }
-            }
-        }),
+            },
+        ),
         err=None,
     )
-    collector = DiscussionCollector(org="dataciviclab", token="fake-token",
-                                    http_client=fake_http)
+    collector = DiscussionCollector(org="dataciviclab", token="fake-token", http_client=fake_http)
 
     results = collector.get_discussions(["dataset-incubator"])
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,4 +1,5 @@
 """Tests for github module HTTP boundary — uses FakeHttpClient."""
+
 from __future__ import annotations
 
 import pytest
@@ -13,8 +14,7 @@ _GITHUB_RAW = "https://raw.githubusercontent.com/test-org/some-repo/main/data/fi
 _GITHUB_API = "https://api.github.com/repos/test-org/some-repo"
 
 
-def _register_get(fake_http, url: str, status: int = 200,
-                  body: str = "", json_data=None):
+def _register_get(fake_http, url: str, status: int = 200, body: str = "", json_data=None):
     """Register a GET response for *url* on *fake_http*."""
     fake_http.responses[url] = HttpResult(
         response=fake_response(status, text=body, json_data=json_data),

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -14,28 +14,31 @@ from agent_context_builder.signals import (
 
 
 def _sample_json(signals: list[dict] | None = None) -> str:
-    return json.dumps({
-        "captured_at": "2026-04-12",
-        "sources_checked": 3,
-        "signals": signals or [
-            {
-                "source": "istat_sdmx",
-                "protocol": "sdmx",
-                "signal_type": "no signal",
-                "result": "stabile",
-                "detail": "Stabile.",
-                "suggested_action": "nessuna",
-            },
-            {
-                "source": "inps",
-                "protocol": "ckan",
-                "signal_type": "inventory change",
-                "result": "inventory change",
-                "detail": "Delta inventario +12 rispetto alla baseline.",
-                "suggested_action": "verificare se variazione attesa",
-            },
-        ],
-    })
+    return json.dumps(
+        {
+            "captured_at": "2026-04-12",
+            "sources_checked": 3,
+            "signals": signals
+            or [
+                {
+                    "source": "istat_sdmx",
+                    "protocol": "sdmx",
+                    "signal_type": "no signal",
+                    "result": "stabile",
+                    "detail": "Stabile.",
+                    "suggested_action": "nessuna",
+                },
+                {
+                    "source": "inps",
+                    "protocol": "ckan",
+                    "signal_type": "inventory change",
+                    "result": "inventory change",
+                    "detail": "Delta inventario +12 rispetto alla baseline.",
+                    "suggested_action": "verificare se variazione attesa",
+                },
+            ],
+        }
+    )
 
 
 @pytest.mark.pure_unit
@@ -63,16 +66,18 @@ def test_drift_alerts_excludes_no_signal():
 
 @pytest.mark.pure_unit
 def test_all_stable_empty_filters():
-    raw = _sample_json([
-        {
-            "source": "istat_sdmx",
-            "protocol": "sdmx",
-            "signal_type": "no signal",
-            "result": "stabile",
-            "detail": "ok",
-            "suggested_action": "nessuna",
-        }
-    ])
+    raw = _sample_json(
+        [
+            {
+                "source": "istat_sdmx",
+                "protocol": "sdmx",
+                "signal_type": "no signal",
+                "result": "stabile",
+                "detail": "ok",
+                "suggested_action": "nessuna",
+            }
+        ]
+    )
     so = parse_source_observatory_signals(raw)
     assert so.regressions == []
     assert so.alerts == []
@@ -102,37 +107,41 @@ def test_alerts_alias_matches_drift_alerts():
 
 # --- parse_repo_signals / RepoSignals ---
 
+
 def _sample_repo_signals_json(signals: list[dict] | None = None) -> str:
-    return json.dumps({
-        "schema_version": "1",
-        "generated_at": "2026-04-16T10:00:00",
-        "repo": "dataciviclab/dataset-incubator",
-        "topic": "pipeline_state",
-        "signals": signals or [
-            {
-                "id": "irpef-comunale",
-                "status": "ok",
-                "label": "irpef-comunale (2022-2023)",
-                "detail": "single-source, mart SQL presente",
-                "action": "",
-            },
-            {
-                "id": "ispra-ru-base",
-                "status": "warn",
-                "label": "ispra-ru-base (2020-2023)",
-                "detail": "nessun mart SQL trovato",
-                "action": "aggiungere mart SQL",
-            },
-            {
-                "id": "broken-candidate",
-                "status": "error",
-                "label": "broken-candidate",
-                "detail": "struttura non riconosciuta",
-                "action": "verificare dataset.yml",
-            },
-        ],
-        "summary": {"ok": 1, "warn": 1, "error": 1},
-    })
+    return json.dumps(
+        {
+            "schema_version": "1",
+            "generated_at": "2026-04-16T10:00:00",
+            "repo": "dataciviclab/dataset-incubator",
+            "topic": "pipeline_state",
+            "signals": signals
+            or [
+                {
+                    "id": "irpef-comunale",
+                    "status": "ok",
+                    "label": "irpef-comunale (2022-2023)",
+                    "detail": "single-source, mart SQL presente",
+                    "action": "",
+                },
+                {
+                    "id": "ispra-ru-base",
+                    "status": "warn",
+                    "label": "ispra-ru-base (2020-2023)",
+                    "detail": "nessun mart SQL trovato",
+                    "action": "aggiungere mart SQL",
+                },
+                {
+                    "id": "broken-candidate",
+                    "status": "error",
+                    "label": "broken-candidate",
+                    "detail": "struttura non riconosciuta",
+                    "action": "verificare dataset.yml",
+                },
+            ],
+            "summary": {"ok": 1, "warn": 1, "error": 1},
+        }
+    )
 
 
 @pytest.mark.pure_unit
@@ -155,9 +164,11 @@ def test_parse_repo_signals_actionable():
 
 @pytest.mark.pure_unit
 def test_parse_repo_signals_all_ok():
-    raw = _sample_repo_signals_json([
-        {"id": "a", "status": "ok", "label": "a", "detail": "", "action": ""},
-    ])
+    raw = _sample_repo_signals_json(
+        [
+            {"id": "a", "status": "ok", "label": "a", "detail": "", "action": ""},
+        ]
+    )
     rs = parse_repo_signals(raw)
     assert rs.actionable == []
 
@@ -180,29 +191,31 @@ def test_parse_repo_signals_missing_fields_use_defaults():
 @pytest.mark.contract
 def test_parse_repo_signals_sample_run_parsing():
     """sample_run fields are parsed and exposed on RepoSignal."""
-    raw = json.dumps({
-        "schema_version": "1",
-        "generated_at": "2026-04-30",
-        "repo": "di",
-        "topic": "pipeline",
-        "signals": [
-            {
-                "id": "test-candidate",
-                "status": "ok",
-                "label": "test-candidate",
-                "detail": "ok",
-                "action": "",
-                "sample_run": {
-                    "status": "failed",
-                    "run_id": "12345",
-                    "run_url": "https://github.com/.../actions/runs/12345",
-                    "checked_at": "2026-04-30",
-                    "year": 2020,
-                    "config_path": "candidates/test-candidate/dataset.yml",
+    raw = json.dumps(
+        {
+            "schema_version": "1",
+            "generated_at": "2026-04-30",
+            "repo": "di",
+            "topic": "pipeline",
+            "signals": [
+                {
+                    "id": "test-candidate",
+                    "status": "ok",
+                    "label": "test-candidate",
+                    "detail": "ok",
+                    "action": "",
+                    "sample_run": {
+                        "status": "failed",
+                        "run_id": "12345",
+                        "run_url": "https://github.com/.../actions/runs/12345",
+                        "checked_at": "2026-04-30",
+                        "year": 2020,
+                        "config_path": "candidates/test-candidate/dataset.yml",
+                    },
                 },
-            },
-        ],
-    })
+            ],
+        }
+    )
     rs = parse_repo_signals(raw)
     assert len(rs.signals) == 1
     sr = rs.signals[0]
@@ -215,13 +228,15 @@ def test_parse_repo_signals_sample_run_parsing():
 @pytest.mark.pure_unit
 def test_parse_repo_signals_no_sample_run():
     """Signal without sample_run has None."""
-    raw = json.dumps({
-        "schema_version": "1",
-        "generated_at": "2026-04-30",
-        "repo": "di",
-        "topic": "pipeline",
-        "signals": [{"id": "a", "status": "ok", "label": "a", "detail": "", "action": ""}],
-    })
+    raw = json.dumps(
+        {
+            "schema_version": "1",
+            "generated_at": "2026-04-30",
+            "repo": "di",
+            "topic": "pipeline",
+            "signals": [{"id": "a", "status": "ok", "label": "a", "detail": "", "action": ""}],
+        }
+    )
     rs = parse_repo_signals(raw)
     assert rs.signals[0].sample_run is None
 
@@ -229,27 +244,33 @@ def test_parse_repo_signals_no_sample_run():
 @pytest.mark.pure_unit
 def test_failed_runs_property():
     """failed_runs returns only signals with a failed sample_run."""
-    raw = json.dumps({
-        "schema_version": "1",
-        "generated_at": "2026-04-30",
-        "repo": "di",
-        "topic": "pipeline",
-        "signals": [
-            {"id": "ok-signal", "status": "ok", "label": "ok", "detail": "", "action": ""},
-            {
-                "id": "failed-signal",
-                "status": "ok",
-                "label": "failed-signal",
-                "detail": "",
-                "action": "",
-                "sample_run": {
-                    "status": "failed", "run_id": "1", "run_url": "x",
-                    "checked_at": "x", "year": 2020, "config_path": "x.yml",
+    raw = json.dumps(
+        {
+            "schema_version": "1",
+            "generated_at": "2026-04-30",
+            "repo": "di",
+            "topic": "pipeline",
+            "signals": [
+                {"id": "ok-signal", "status": "ok", "label": "ok", "detail": "", "action": ""},
+                {
+                    "id": "failed-signal",
+                    "status": "ok",
+                    "label": "failed-signal",
+                    "detail": "",
+                    "action": "",
+                    "sample_run": {
+                        "status": "failed",
+                        "run_id": "1",
+                        "run_url": "x",
+                        "checked_at": "x",
+                        "year": 2020,
+                        "config_path": "x.yml",
+                    },
                 },
-            },
-            {"id": "ok-signal-2", "status": "ok", "label": "ok2", "detail": "", "action": ""},
-        ],
-    })
+                {"id": "ok-signal-2", "status": "ok", "label": "ok2", "detail": "", "action": ""},
+            ],
+        }
+    )
     rs = parse_repo_signals(raw)
     assert len(rs.failed_runs) == 1
     assert rs.failed_runs[0].id == "failed-signal"
@@ -258,16 +279,18 @@ def test_failed_runs_property():
 @pytest.mark.pure_unit
 def test_candidates_property():
     """candidates returns datasets with stage != published."""
-    raw = json.dumps({
-        "schema_version": "1",
-        "name": "Test",
-        "updated_at": "2026-04-30",
-        "datasets": [
-            {"slug": "ready", "name": "Ready", "stage": "published", "columns": []},
-            {"slug": "cand", "name": "Candidate", "stage": "incubating", "columns": []},
-            {"slug": "cand2", "name": "Candidate 2", "stage": "incubating", "columns": []},
-        ],
-    })
+    raw = json.dumps(
+        {
+            "schema_version": "1",
+            "name": "Test",
+            "updated_at": "2026-04-30",
+            "datasets": [
+                {"slug": "ready", "name": "Ready", "stage": "published", "columns": []},
+                {"slug": "cand", "name": "Candidate", "stage": "incubating", "columns": []},
+                {"slug": "cand2", "name": "Candidate 2", "stage": "incubating", "columns": []},
+            ],
+        }
+    )
     catalog = parse_di_clean_catalog(raw)
     assert len(catalog.clean_ready) == 1
     assert len(catalog.candidates) == 2
@@ -277,22 +300,34 @@ def test_candidates_property():
 @pytest.mark.contract
 def test_di_clean_catalog_columns_parsed():
     """Column name and role are parsed; type and description are excluded."""
-    raw = json.dumps({
-        "schema_version": "1",
-        "name": "Test",
-        "updated_at": "2026-04-30",
-        "datasets": [
-            {
-                "slug": "test",
-                "name": "Test",
-                "stage": "published",
-                "columns": [
-                    {"name": "anno", "type": "INTEGER", "role": "dimension", "description": "Year"},
-                    {"name": "valore", "type": "FLOAT", "role": "metric", "description": "Value"},
-                ],
-            }
-        ],
-    })
+    raw = json.dumps(
+        {
+            "schema_version": "1",
+            "name": "Test",
+            "updated_at": "2026-04-30",
+            "datasets": [
+                {
+                    "slug": "test",
+                    "name": "Test",
+                    "stage": "published",
+                    "columns": [
+                        {
+                            "name": "anno",
+                            "type": "INTEGER",
+                            "role": "dimension",
+                            "description": "Year",
+                        },
+                        {
+                            "name": "valore",
+                            "type": "FLOAT",
+                            "role": "metric",
+                            "description": "Value",
+                        },
+                    ],
+                }
+            ],
+        }
+    )
     catalog = parse_di_clean_catalog(raw)
     ds = catalog.datasets[0]
     assert len(ds.columns) == 2
@@ -306,28 +341,55 @@ def test_di_clean_catalog_columns_parsed():
 def test_parse_radar_summary():
     from agent_context_builder.signals import parse_radar_summary
 
-    raw = json.dumps({
-        "generated_at": "2026-04-19T09:00:00+00:00",
-        "probe_date": "2026-04-19",
-        "sources_total": 3,
-        "status_counts": {"GREEN": 2, "YELLOW": 1, "RED": 0},
-        "persistent_red": 1,
-        "sources": [
-            {"id": "inps", "status": "GREEN", "protocol": "ckan",
-             "observation_mode": "catalog-watch", "http_code": "200",
-             "last_check": "2026-04-19", "datasets_in_use": ["ds1"]},
-            {"id": "anac", "status": "YELLOW", "protocol": "ckan",
-             "observation_mode": "radar-only", "http_code": "200",
-             "last_check": "2026-04-19", "datasets_in_use": []},
-            {"id": "dati_salute", "status": "RED", "protocol": "html",
-             "observation_mode": "radar-only", "http_code": "-",
-             "last_check": "2026-04-19", "datasets_in_use": [],
-             "note": "SSL verify failed", "red_streak": 2},
-            {"id": "istat", "status": "GREEN", "protocol": "sdmx",
-             "observation_mode": "catalog-watch", "http_code": "200",
-             "last_check": "2026-04-19", "datasets_in_use": []},
-        ],
-    })
+    raw = json.dumps(
+        {
+            "generated_at": "2026-04-19T09:00:00+00:00",
+            "probe_date": "2026-04-19",
+            "sources_total": 3,
+            "status_counts": {"GREEN": 2, "YELLOW": 1, "RED": 0},
+            "persistent_red": 1,
+            "sources": [
+                {
+                    "id": "inps",
+                    "status": "GREEN",
+                    "protocol": "ckan",
+                    "observation_mode": "catalog-watch",
+                    "http_code": "200",
+                    "last_check": "2026-04-19",
+                    "datasets_in_use": ["ds1"],
+                },
+                {
+                    "id": "anac",
+                    "status": "YELLOW",
+                    "protocol": "ckan",
+                    "observation_mode": "radar-only",
+                    "http_code": "200",
+                    "last_check": "2026-04-19",
+                    "datasets_in_use": [],
+                },
+                {
+                    "id": "dati_salute",
+                    "status": "RED",
+                    "protocol": "html",
+                    "observation_mode": "radar-only",
+                    "http_code": "-",
+                    "last_check": "2026-04-19",
+                    "datasets_in_use": [],
+                    "note": "SSL verify failed",
+                    "red_streak": 2,
+                },
+                {
+                    "id": "istat",
+                    "status": "GREEN",
+                    "protocol": "sdmx",
+                    "observation_mode": "catalog-watch",
+                    "http_code": "200",
+                    "last_check": "2026-04-19",
+                    "datasets_in_use": [],
+                },
+            ],
+        }
+    )
     summary = parse_radar_summary(raw)
     assert summary.sources_total == 3
     assert summary.green == 2
@@ -343,25 +405,27 @@ def test_parse_radar_summary():
 
 @pytest.mark.contract
 def test_parse_di_clean_catalog_basic():
-    raw = json.dumps({
-        "schema_version": 1,
-        "name": "Lab Clean Registry",
-        "updated_at": "2026-04-14",
-        "datasets": [
-            {
-                "slug": "irpef_comunale",
-                "name": "IRPEF Comunale",
-                "stage": "published",
-                "period": {"start": 2022, "end": 2023},
-                "location": {"type": "gcs", "path": "gs://bucket/irpef.parquet"},
-                "columns": [
-                    {"name": "anno", "role": "dimension"},
-                    {"name": "comune", "role": "dimension"},
-                    {"name": "imposta", "role": "metric"},
-                ],
-            }
-        ],
-    })
+    raw = json.dumps(
+        {
+            "schema_version": 1,
+            "name": "Lab Clean Registry",
+            "updated_at": "2026-04-14",
+            "datasets": [
+                {
+                    "slug": "irpef_comunale",
+                    "name": "IRPEF Comunale",
+                    "stage": "published",
+                    "period": {"start": 2022, "end": 2023},
+                    "location": {"type": "gcs", "path": "gs://bucket/irpef.parquet"},
+                    "columns": [
+                        {"name": "anno", "role": "dimension"},
+                        {"name": "comune", "role": "dimension"},
+                        {"name": "imposta", "role": "metric"},
+                    ],
+                }
+            ],
+        }
+    )
 
     catalog = parse_di_clean_catalog(raw)
 
@@ -435,7 +499,7 @@ def test_parse_themes_from_py_basic():
 @pytest.mark.pure_unit
 def test_parse_themes_from_py_empty_list():
     """Empty themes list returns empty list."""
-    themes = parse_explorer_themes_from_py('themes = []')
+    themes = parse_explorer_themes_from_py("themes = []")
     assert themes == []
 
 
@@ -541,8 +605,11 @@ json.dump(themes, sys.stdout, ensure_ascii=False)
     assert len(themes) == 5
     slugs = [t.slug for t in themes]
     assert slugs == [
-        "territorio-ambiente", "finanza-pubblica",
-        "sanita", "welfare-lavoro", "giustizia",
+        "territorio-ambiente",
+        "finanza-pubblica",
+        "sanita",
+        "welfare-lavoro",
+        "giustizia",
     ]
     assert themes[2].datasets == ["spesa-farmaceutica"]
     assert themes[3].name == "Welfare e lavoro"


### PR DESCRIPTION
## Sintesi

Aggiunge `.pre-commit-config.yaml` con ruff (lint + format) e hook standard.
Aggiunge `.editorconfig`.

Allinea agent-context-builder alla policy già attiva in toolkit e lab-connectors.

## Cosa cambia

- Nuovo `.pre-commit-config.yaml` con ruff + ruff-format
- Nuovo `.editorconfig`

## Verifica

```bash
pre-commit run --all-files  # tutto verde
```

## Checklist PR

- [x] Perimetro stretto: tooling, zero logica
