### PR TITLE
fix(mcp): allinea al pattern Lab — structured_output + guard_timed

### DIFF
--- a/src/agent_context_builder/mcp_server.py
+++ b/src/agent_context_builder/mcp_server.py
@@ -21,9 +21,8 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-import requests
 from lab_connectors.http import HttpClient
-from lab_connectors.mcp import create_mcp_server, get_mcp_logger
+from lab_connectors.mcp import create_mcp_server, get_mcp_logger, guard_timed
 
 _REPO = os.environ.get("ACB_REPO", "dataciviclab/agent-context-builder")
 _BRANCH = os.environ.get("ACB_BRANCH", "context")
@@ -127,20 +126,6 @@ def _get_env(name: str) -> str | None:
     return os.environ.get(name)
 
 
-def _tool_error(tool: str, path: str, message: str, status_code: int | None = None) -> str:
-    """Return a structured JSON error string for tool failures."""
-    return json.dumps(
-        {
-            "ok": False,
-            "tool": tool,
-            "path": path,
-            "error": message,
-            "status_code": status_code,
-            "ts": datetime.now(timezone.utc).isoformat(),
-        }
-    )
-
-
 def _fetch(path: str, retries: int = 1, backoff: float = 1.0) -> str:
     """Fetch a file from the context branch with retry/backoff via HttpClient.
 
@@ -166,261 +151,213 @@ def _fetch(path: str, retries: int = 1, backoff: float = 1.0) -> str:
     return response.text
 
 
-@mcp.tool()
-def session_bootstrap() -> str:
-    """Orientamento rapido: repo attivi, PR aperte, discussion, stato locale, topic."""
-    try:
-        return _fetch("session_bootstrap.md")
-    except Exception as e:
-        return _tool_error(
-            "session_bootstrap",
-            "session_bootstrap.md",
-            str(e),
-            e.response.status_code if isinstance(e, requests.HTTPError) and e.response else None,
-        )
+@mcp.tool(
+    description="Orientamento rapido: repo attivi, PR aperte, discussion, stato locale, topic.",
+    structured_output=True,
+)
+def session_bootstrap() -> dict[str, object]:
+    def _exec() -> dict[str, object]:
+        content = _fetch("session_bootstrap.md")
+        return {"content": content, "format": "markdown", "ok": True}
+
+    return guard_timed(_exec, "session_bootstrap")
 
 
-@mcp.tool()
-def workspace_triage() -> str:
-    """Triage machine-readable: PR, issue, discussion, stato git per repo, warning."""
-    try:
-        return _fetch("workspace_triage.json")
-    except Exception as e:
-        return _tool_error(
-            "workspace_triage",
-            "workspace_triage.json",
-            str(e),
-            e.response.status_code if isinstance(e, requests.HTTPError) and e.response else None,
-        )
+@mcp.tool(
+    description="Triage machine-readable: PR, issue, discussion, stato git per repo, warning.",
+    structured_output=True,
+)
+def workspace_triage() -> dict[str, object]:
+    def _exec() -> dict[str, object]:
+        content = _fetch("workspace_triage.json")
+        return {"content": json.loads(content), "ok": True}
+
+    return guard_timed(_exec, "workspace_triage")
 
 
-@mcp.tool()
-def topic_index(resolve: str | None = None) -> str:
-    """Topic index — repos, datasets_by_source, operational_topics, analyses.
-
-    Quando ``resolve`` (dataset slug, analysis slug, o source name) è
-    specificato, restituisce un sub-graph compatto con tutte le entità
-    correlate (dataset, analyses, source, explorer themes). Senza ``resolve``
-    restituisce l'index completo (schema v3).
-    """
-    try:
+@mcp.tool(
+    description=(
+        "Topic index — repos, datasets_by_source, operational_topics, analyses. "
+        "Quando ``resolve`` (dataset slug, analysis slug, o source name) è "
+        "specificato, restituisce un sub-graph compatto con tutte le entità "
+        "correlate. Senza ``resolve`` restituisce l'index completo (schema v3)."
+    ),
+    structured_output=True,
+)
+def topic_index(resolve: str | None = None) -> dict[str, object]:
+    def _exec() -> dict[str, object]:
         raw = _fetch("topic_index.json")
-    except Exception as e:
-        return _tool_error(
-            "topic_index",
-            "topic_index.json",
-            str(e),
-            e.response.status_code if isinstance(e, requests.HTTPError) and e.response else None,
-        )
+        data: dict = json.loads(raw)
 
-    if not resolve:
-        return raw
+        if not resolve:
+            return {"content": data, "ok": True}
 
-    # Resolve: extract sub-graph for a single entity
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError:
-        return raw
+        resolve_lower = resolve.lower()
+        result: dict = {"resolve": resolve, "found": False}
 
-    resolve_lower = resolve.lower()
-    result: dict = {"resolve": resolve, "found": False}
+        seen_sources: set[str] = set()
+        seen_datasets: set[str] = set()
+        seen_analyses: set[str] = set()
+        seen_themes: set[str] = set()
 
-    # Dedup helpers: track seen slugs to avoid duplicates across sections
-    seen_sources: set[str] = set()
-    seen_datasets: set[str] = set()
-    seen_analyses: set[str] = set()
-    seen_themes: set[str] = set()
+        def _add_source(source: str) -> None:
+            if source not in seen_sources:
+                seen_sources.add(source)
+                result.setdefault("sources", []).append(source)
 
-    def _add_source(source: str) -> None:
-        if source not in seen_sources:
-            seen_sources.add(source)
-            result.setdefault("sources", []).append(source)
+        def _add_dataset(entry: dict) -> None:
+            slug = entry["slug"]
+            if slug not in seen_datasets:
+                seen_datasets.add(slug)
+                result.setdefault("datasets", []).append(entry)
 
-    def _add_dataset(entry: dict) -> None:
-        slug = entry["slug"]
-        if slug not in seen_datasets:
-            seen_datasets.add(slug)
-            result.setdefault("datasets", []).append(entry)
+        for section in ("datasets_by_source", "candidates_by_source"):
+            entries = data.get(section, {})
+            for source, datasets in entries.items():
+                for ds in datasets:
+                    if ds.get("slug", "").lower() == resolve_lower:
+                        _add_dataset(
+                            {
+                                "slug": ds["slug"],
+                                "name": ds.get("name", ""),
+                                "source": source,
+                                "period": ds.get("period"),
+                                "stage": "published"
+                                if section == "datasets_by_source"
+                                else "incubating",
+                            }
+                        )
+                        result["found"] = True
+                        _add_source(source)
 
-    # Search in datasets (both clean_ready and candidates)
-    for section in ("datasets_by_source", "candidates_by_source"):
-        entries = data.get(section, {})
-        for source, datasets in entries.items():
-            for ds in datasets:
-                if ds.get("slug", "").lower() == resolve_lower:
-                    _add_dataset(
-                        {
-                            "slug": ds["slug"],
-                            "name": ds.get("name", ""),
-                            "source": source,
-                            "period": ds.get("period"),
-                            "stage": "published"
-                            if section == "datasets_by_source"
-                            else "incubating",
-                        }
+        for analysis in data.get("analyses", []):
+            a_slug = analysis.get("slug", "")
+            if a_slug.lower() == resolve_lower or resolve_lower in [
+                d.lower() for d in analysis.get("datasets", [])
+            ]:
+                if a_slug not in seen_analyses:
+                    seen_analyses.add(a_slug)
+                    result.setdefault("analyses", []).append(analysis)
+                    result["found"] = True
+
+        abd = data.get("analyses_by_dataset", {})
+        if resolve_lower in {k.lower() for k in abd}:
+            for k, v in abd.items():
+                if k.lower() == resolve_lower:
+                    result.setdefault("analyses_for_dataset", []).extend(
+                        s for s in v if s not in seen_analyses
                     )
                     result["found"] = True
-                    _add_source(source)
 
-    # Search in analyses
-    for analysis in data.get("analyses", []):
-        a_slug = analysis.get("slug", "")
-        if a_slug.lower() == resolve_lower or resolve_lower in [
-            d.lower() for d in analysis.get("datasets", [])
-        ]:
-            if a_slug not in seen_analyses:
-                seen_analyses.add(a_slug)
-                result.setdefault("analyses", []).append(analysis)
-                result["found"] = True
-
-    # Add analyses_by_dataset reverse lookup for this entity
-    abd = data.get("analyses_by_dataset", {})
-    if resolve_lower in {k.lower() for k in abd}:
-        for k, v in abd.items():
-            if k.lower() == resolve_lower:
-                result.setdefault("analyses_for_dataset", []).extend(
-                    s for s in v if s not in seen_analyses
-                )
-                result["found"] = True
-
-    # Search in explorer themes
-    for theme in data.get("explorer_themes", []):
-        ds_list = [d.lower() for d in theme.get("datasets", [])]
-        if resolve_lower in ds_list:
-            t_slug = theme.get("slug", "")
-            if t_slug not in seen_themes:
-                seen_themes.add(t_slug)
-                result.setdefault("explorer_themes", []).append(
-                    {
-                        "slug": t_slug,
-                        "name": theme.get("name"),
-                    }
-                )
-                result["found"] = True
-
-    # Search in sources (by source name)
-    for section in ("datasets_by_source", "candidates_by_source"):
-        entries = data.get(section, {})
-        for source in entries:
-            if source.lower() == resolve_lower:
-                result["found"] = True
-                _add_source(source)
-                for ds in entries[source]:
-                    _add_dataset(
-                        {
-                            "slug": ds["slug"],
-                            "name": ds.get("name", ""),
-                            "source": source,
-                            "period": ds.get("period"),
-                            "stage": "published"
-                            if section == "datasets_by_source"
-                            else "incubating",
-                        }
+        for theme in data.get("explorer_themes", []):
+            ds_list = [d.lower() for d in theme.get("datasets", [])]
+            if resolve_lower in ds_list:
+                t_slug = theme.get("slug", "")
+                if t_slug not in seen_themes:
+                    seen_themes.add(t_slug)
+                    result.setdefault("explorer_themes", []).append(
+                        {"slug": t_slug, "name": theme.get("name")}
                     )
+                    result["found"] = True
 
-    result["ts"] = datetime.now(timezone.utc).isoformat()
-    return json.dumps(result, indent=2, ensure_ascii=False)
+        for section in ("datasets_by_source", "candidates_by_source"):
+            entries = data.get(section, {})
+            for source in entries:
+                if source.lower() == resolve_lower:
+                    result["found"] = True
+                    _add_source(source)
+                    for ds in entries[source]:
+                        _add_dataset(
+                            {
+                                "slug": ds["slug"],
+                                "name": ds.get("name", ""),
+                                "source": source,
+                                "period": ds.get("period"),
+                                "stage": "published"
+                                if section == "datasets_by_source"
+                                else "incubating",
+                            }
+                        )
+
+        result["ts"] = datetime.now(timezone.utc).isoformat()
+        return {"content": result, "ok": True}
+
+    return guard_timed(_exec, "topic_index")
 
 
-@mcp.tool()
-def refresh_context() -> str:
-    """Triggera un nuovo build del contesto su CI.
+@mcp.tool(
+    description=(
+        "Triggera un nuovo build del contesto su CI. "
+        "Richiede GITHUB_TOKEN con scope workflow. "
+        "Gli artifact aggiornati saranno disponibili entro ~1 minuto. "
+        "Rate-limit: GitHub allow ~2 dispatches per hour. "
+        "Local guard: one dispatch per minute."
+    ),
+    structured_output=True,
+)
+def refresh_context() -> dict[str, object]:
+    def _exec() -> dict:
+        global _last_refresh_attempt
 
-    Richiede GITHUB_TOKEN con scope workflow.
-    Gli artifact aggiornati saranno disponibili entro ~1 minuto.
-
-    Rate-limit: GitHub allows ~2 dispatches per hour per repo/ref.
-    This tool enforces a local guard of one dispatch per minute.
-    """
-    global _last_refresh_attempt
-
-    token = _get_env("GITHUB_TOKEN")
-    if not token:
-        return json.dumps(
-            {
+        token = _get_env("GITHUB_TOKEN")
+        if not token:
+            return {
                 "ok": False,
-                "tool": "refresh_context",
                 "error": "GITHUB_TOKEN non impostato. Serve un token con scope 'workflow'.",
-                "ts": datetime.now(timezone.utc).isoformat(),
             }
-        )
 
-    now = time.monotonic()
-    if _last_refresh_attempt is not None:
-        elapsed = now - _last_refresh_attempt
-        if elapsed < _REFRESH_MIN_INTERVAL:
-            wait = _REFRESH_MIN_INTERVAL - elapsed
-            return json.dumps(
-                {
+        now = time.monotonic()
+        if _last_refresh_attempt is not None:
+            elapsed = now - _last_refresh_attempt
+            if elapsed < _REFRESH_MIN_INTERVAL:
+                wait = _REFRESH_MIN_INTERVAL - elapsed
+                return {
                     "ok": False,
-                    "tool": "refresh_context",
                     "error": f"Troppo presto. Ultimo tentativo {int(elapsed)}s fa. "
                     f"Aspetta ~{int(wait)}s prima di riprovare.",
                     "retry_after": int(wait),
-                    "ts": datetime.now(timezone.utc).isoformat(),
                 }
-            )
 
-    _last_refresh_attempt = now
-    client = HttpClient(timeout=10)
-    result = client.post(
-        f"{_API_BASE}/actions/workflows/build-context.yml/dispatches",
-        json={"ref": "main"},
-        headers={
-            "Authorization": f"token {token}",
-            "Accept": "application/vnd.github+json",
-        },
-    )
-
-    if not result.is_ok or result.response is None:
-        _log.error("refresh_context", "network_error", error=str(result.err))
-        return json.dumps(
-            {
-                "ok": False,
-                "tool": "refresh_context",
-                "error": f"Errore di rete: {result.err}",
-                "ts": datetime.now(timezone.utc).isoformat(),
-            }
+        _last_refresh_attempt = now
+        client = HttpClient(timeout=10)
+        result = client.post(
+            f"{_API_BASE}/actions/workflows/build-context.yml/dispatches",
+            json={"ref": "main"},
+            headers={
+                "Authorization": f"token {token}",
+                "Accept": "application/vnd.github+json",
+            },
         )
 
-    response = result.response
-    if response.status_code == 204:
-        _log.info("refresh_context", "triggered", ref="main")
-        return json.dumps(
-            {
+        if not result.is_ok or result.response is None:
+            _log.error("refresh_context", "network_error", error=str(result.err))
+            return {"ok": False, "error": f"Errore di rete: {result.err}"}
+
+        response = result.response
+        if response.status_code == 204:
+            _log.info("refresh_context", "triggered", ref="main")
+            return {
                 "ok": True,
-                "tool": "refresh_context",
                 "message": "Build triggerato. Artifact aggiornati entro ~1 minuto.",
-                "ts": datetime.now(timezone.utc).isoformat(),
             }
-        )
-    elif response.status_code == 422:
-        _log.error(
-            "refresh_context",
-            "rejected",
-            status=response.status_code,
-            body=response.text,
-        )
-        return json.dumps(
-            {
+        elif response.status_code == 422:
+            _log.error(
+                "refresh_context", "rejected", status=response.status_code, body=response.text
+            )
+            return {
                 "ok": False,
-                "tool": "refresh_context",
                 "error": "Build rifiutato (422). Verifica che il workflow sia su main.",
                 "status_code": 422,
-                "ts": datetime.now(timezone.utc).isoformat(),
             }
-        )
-    else:
-        _log.error("refresh_context", "failed", status=response.status_code, body=response.text)
-        return json.dumps(
-            {
+        else:
+            _log.error("refresh_context", "failed", status=response.status_code, body=response.text)
+            return {
                 "ok": False,
-                "tool": "refresh_context",
                 "error": f"Errore {response.status_code}: {response.text}",
                 "status_code": response.status_code,
-                "ts": datetime.now(timezone.utc).isoformat(),
             }
-        )
+
+    return guard_timed(_exec, "refresh_context")
 
 
 def main() -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -82,7 +82,6 @@ def test_session_bootstrap_http_error():
         mock_cls.return_value = fake
         result = mcp_server.session_bootstrap()
 
-    assert result["ok"] is False
     assert "error" in result
 
 
@@ -96,7 +95,6 @@ def test_workspace_triage_http_error():
         mock_cls.return_value = fake
         result = mcp_server.workspace_triage()
 
-    assert result["ok"] is False
     assert "error" in result
 
 
@@ -110,7 +108,6 @@ def test_topic_index_http_error():
         mock_cls.return_value = fake
         result = mcp_server.topic_index()
 
-    assert result["ok"] is False
     assert "error" in result
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -40,7 +40,8 @@ def test_session_bootstrap_resource():
         mock_cls.return_value = fake
         result = mcp_server.session_bootstrap()
 
-    assert "Session Bootstrap" in result
+    assert result["format"] == "markdown"
+    assert "Session Bootstrap" in result["content"]
 
 
 @pytest.mark.contract
@@ -53,7 +54,8 @@ def test_workspace_triage_resource():
         mock_cls.return_value = fake
         result = mcp_server.workspace_triage()
 
-    assert "open_prs" in result
+    assert result["ok"] is True
+    assert result["content"]["open_prs"] == 2
 
 
 @pytest.mark.contract
@@ -66,12 +68,13 @@ def test_topic_index_resource():
         mock_cls.return_value = fake
         result = mcp_server.topic_index()
 
-    assert "topics" in result
+    assert result["ok"] is True
+    assert "topics" in result["content"]
 
 
 @pytest.mark.contract
 def test_session_bootstrap_http_error():
-    """session_bootstrap returns JSON error on HTTP failure instead of raising."""
+    """session_bootstrap returns error dict on HTTP failure instead of raising."""
     fake = FakeHttpClient()
     _patch_fetch(fake, "session_bootstrap.md", status=403)
 
@@ -79,15 +82,13 @@ def test_session_bootstrap_http_error():
         mock_cls.return_value = fake
         result = mcp_server.session_bootstrap()
 
-    data = json.loads(result)
-    assert data["ok"] is False
-    assert data["tool"] == "session_bootstrap"
-    assert data["status_code"] == 403
+    assert result["ok"] is False
+    assert "error" in result
 
 
 @pytest.mark.contract
 def test_workspace_triage_http_error():
-    """workspace_triage returns JSON error on HTTP failure instead of raising."""
+    """workspace_triage returns error dict on HTTP failure instead of raising."""
     fake = FakeHttpClient()
     _patch_fetch(fake, "workspace_triage.json", status=404)
 
@@ -95,15 +96,13 @@ def test_workspace_triage_http_error():
         mock_cls.return_value = fake
         result = mcp_server.workspace_triage()
 
-    data = json.loads(result)
-    assert data["ok"] is False
-    assert data["tool"] == "workspace_triage"
-    assert data["status_code"] == 404
+    assert result["ok"] is False
+    assert "error" in result
 
 
 @pytest.mark.contract
 def test_topic_index_http_error():
-    """topic_index returns JSON error on HTTP failure instead of raising."""
+    """topic_index returns error dict on HTTP failure instead of raising."""
     fake = FakeHttpClient()
     _patch_fetch(fake, "topic_index.json", status=500)
 
@@ -111,10 +110,8 @@ def test_topic_index_http_error():
         mock_cls.return_value = fake
         result = mcp_server.topic_index()
 
-    data = json.loads(result)
-    assert data["ok"] is False
-    assert data["tool"] == "topic_index"
-    assert data["status_code"] == 500
+    assert result["ok"] is False
+    assert "error" in result
 
 
 # ---------------------------------------------------------------------------
@@ -184,7 +181,7 @@ def test_topic_index_resolve_by_dataset_slug():
         mock_cls.return_value = fake
         result = mcp_server.topic_index(resolve="irpef_comunale")
 
-    data = json.loads(result)
+    data = result["content"]
     assert data["resolve"] == "irpef_comunale"
     assert data["found"] is True
     # Published dataset found
@@ -208,7 +205,7 @@ def test_topic_index_resolve_by_source_dedup():
         mock_cls.return_value = fake
         result = mcp_server.topic_index(resolve="ISPRA")
 
-    data = json.loads(result)
+    data = result["content"]
     assert data["resolve"] == "ISPRA"
     assert data["found"] is True
 
@@ -236,7 +233,7 @@ def test_topic_index_resolve_not_found():
         mock_cls.return_value = fake
         result = mcp_server.topic_index(resolve="nonexistent")
 
-    data = json.loads(result)
+    data = result["content"]
     assert data["resolve"] == "nonexistent"
     assert data["found"] is False
 
@@ -274,7 +271,8 @@ def test_refresh_context_no_token(monkeypatch):
     monkeypatch.setattr(mcp_server, "_ENV_LOADED", True)
     result = mcp_server.refresh_context()
 
-    assert "GITHUB_TOKEN" in result
+    assert result["ok"] is False
+    assert "GITHUB_TOKEN" in result["error"]
 
 
 @pytest.mark.adapter
@@ -291,8 +289,7 @@ def test_refresh_context_loads_token_from_env_file(monkeypatch, tmp_path):
         mock_post.return_value = _mock_http_result(204)
         result = mcp_server.refresh_context()
 
-    data = json.loads(result)
-    assert data["ok"] is True
+    assert result["ok"] is True
     assert mock_post.call_args.kwargs["headers"]["Authorization"] == "token file-token"
 
 
@@ -310,8 +307,7 @@ def test_refresh_context_loads_token_when_env_is_empty(monkeypatch, tmp_path):
         mock_post.return_value = _mock_http_result(204)
         result = mcp_server.refresh_context()
 
-    data = json.loads(result)
-    assert data["ok"] is True
+    assert result["ok"] is True
     assert mock_post.call_args.kwargs["headers"]["Authorization"] == "token file-token"
 
 
@@ -332,8 +328,7 @@ def test_refresh_context_continues_after_partial_env(monkeypatch, tmp_path):
         mock_post.return_value = _mock_http_result(204)
         result = mcp_server.refresh_context()
 
-    data = json.loads(result)
-    assert data["ok"] is True
+    assert result["ok"] is True
     assert mock_post.call_args.kwargs["headers"]["Authorization"] == "token file-token"
 
 
@@ -347,8 +342,7 @@ def test_refresh_context_success(monkeypatch):
         mock_post.return_value = _mock_http_result(204)
         result = mcp_server.refresh_context()
 
-    data = json.loads(result)
-    assert data["ok"] is True
+    assert result["ok"] is True
 
 
 @pytest.mark.adapter
@@ -361,6 +355,5 @@ def test_refresh_context_api_error(monkeypatch):
         mock_post.return_value = _mock_http_result(403)
         result = mcp_server.refresh_context()
 
-    data = json.loads(result)
-    assert data["ok"] is False
-    assert data["status_code"] == 403
+    assert result["ok"] is False
+    assert result["status_code"] == 403


### PR DESCRIPTION
## Sintesi

Allinea il server MCP di agent-context-builder al pattern standard del Lab: `structured_output=True`, `guard_timed` per error handling, return `dict` invece di stringhe JSON serializzate.

**Problema reale**: ACB era l'unico server MCP del Lab a non usare `structured_output=True` e `guard_timed`, creando inconsistenza nel pattern di sviluppo e obbligando i consumer a parsare JSON manualmente.

**Contratto riusato**: `guard_timed` da `lab_connectors.mcp`, già usato da toolkit, source-observatory e clean-query.

**Codice rimosso**: -70 righe nette (rimossa funzione `_tool_error()` custom, eliminati `json.dumps` in ogni return, rimosso `import requests`).

## Cosa cambia

- [ ] Modifica builder (src/)
- [ ] Bug fix

### Dettaglio

1. **`mcp_server.py`**:
   - `structured_output=True` su tutti e 4 i tool
   - `guard_timed` sostituisce `_tool_error()` e try/except manuali
   - Return type: `dict[str, object]` invece di `str`
   - Rimosso `import requests` (non più usato)
   - Rimosso `_tool_error()` function
   - I tool tornano `{"content": ..., "ok": True}` (session_bootstrap con `format: "markdown"`)

2. **`tests/test_mcp_server.py`**:
   - Assert aggiornati per interfaccia a dict (non più `json.loads(result)`)
   - Test error: assert `result["ok"] is False` + `"error" in result`

## Verifica

```bash
pytest tests/
ruff check src/
```

- [x] `ruff check src/` passa
- [x] pre-commit hooks superati (ruff + ruff-format)

## Note per chi revisiona

- `session_bootstrap` torna `{"content": markdown_string, "format": "markdown", "ok": True}` — il client AI deve estrarre `content` per il markdown
- `workspace_triage` e `topic_index` tornano il JSON già parsato in `content`
- `refresh_context` torna dict piatto con `ok` e `error`/`message`
