### PR TITLE
feat: search(query) MCP tool — cerca cross-repo via GitHub API + topic_index

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ agent-context-mcp
 Tool MCP:
 
 | Tool | Uso |
-|---|---|
+|---|---|---|
 | `session_bootstrap` | orientamento rapido: repo attivi, PR, issue, discussion |
 | `workspace_triage` | triage machine-readable: PR, issue, warning, git state |
 | `topic_index` | indice v2: repos, datasets per fonte, topic operativi |
+| `search(query, limit=10)` | cerca cross-repo in issue, PR, dataset e analisi (GitHub Search API + topic_index) |
 | `refresh_context` | triggera build CI; richiede `GITHUB_TOKEN` con scope `workflow` |
 
 Esempio `settings.json`:
@@ -121,7 +122,7 @@ Il builder non deve crashare per contesto parziale:
 |---|---|
 | rate limit / 403 GitHub | campi `null`, errore in JSON |
 | repo privato senza token | repo saltato, warning registrato |
-| nessun token | discussion saltate |
+| nessun token | discussion saltate; `search()` usa solo topic_index (senza GitHub Search API) |
 | repo locale assente | `available: false`, `reason: path_not_found` |
 | path non git | `available: false`, `reason: not_git_repo` |
 | local mode non attivo | `available: false`, `reason: local_disabled` |

--- a/README.md
+++ b/README.md
@@ -3,31 +3,19 @@
 Genera contesto operativo compatto per agenti [DataCivicLab](https://github.com/dataciviclab)
 da GitHub e, se disponibile, dai checkout locali dei repo Lab.
 
-## Artifact
+ACB è il **layer di contesto** dell'ecosistema: ogni 6 ore scansiona 10 repo,
+colleziona segnali da source-observatory, dataset-incubator e data-explorer,
+e produce artifact che dicono ad agenti e umani *"cosa è successo e cosa serve attenzione"*.
+
+## Artifact prodotti
 
 | Artifact | Versione | Ruolo |
 |---|---|---|
-| `session_bootstrap.md` | — | orientamento rapido per agenti e umani (~40 righe) |
-| `workspace_triage.json` | v1 | PR, issue, discussion, warning, git state |
-| `topic_index.json` | v2 | repos attivi, dataset per fonte, topic operativi |
+| `session_bootstrap.md` | — | orientamento rapido: segnali, PR, discussion, stato git |
+| `workspace_triage.json` | v1 | dati strutturati: issue, PR, discussion, warning, radar, pipeline |
+| `topic_index.json` | v3 | indice navigabile: repos, dataset per fonte, analisi, explorer themes |
 
-La CI aggiorna gli artifact GitHub-only ogni 6 ore sul branch `context`.
-
-## Artifact Consumati
-
-ACB preferisce artifact JSON generati e versionati dai repo Lab rispetto a
-frontmatter o README manuali. Oggi consuma:
-
-| Repo | Path | Uso |
-|---|---|---|
-| `source-observatory` | `data/radar/radar_summary.json` | health complessivo delle fonti nel registry |
-| `source-observatory` | `data/catalog/catalog_signals.json` | drift/inventory per singola fonte |
-| `dataset-incubator` | `registry/pipeline_signals.json` | stato operativo dei dataset candidate |
-| `dataset-incubator` | `registry/clean_catalog.json` | dataset clean/queryable disponibili |
-
-`radar_summary` presidia la connettivita' e la disponibilita'; `catalog_signals` resta sul drift inventariale.
-
-URL raw:
+URL su branch `context`:
 
 ```text
 https://raw.githubusercontent.com/dataciviclab/agent-context-builder/context/session_bootstrap.md
@@ -35,29 +23,61 @@ https://raw.githubusercontent.com/dataciviclab/agent-context-builder/context/wor
 https://raw.githubusercontent.com/dataciviclab/agent-context-builder/context/topic_index.json
 ```
 
-## Utilizzo
+## Artifact consumati da upstream
 
-### Shared mode via MCP
+| Repo | Path | Uso |
+|---|---|---|
+| `source-observatory` | `data/radar/radar_summary.json` | health 33 fonti (GREEN/YELLOW/RED) |
+| `source-observatory` | `data/catalog/catalog_signals.json` | drift inventariale per fonte |
+| `dataset-incubator` | `registry/pipeline_signals.json` | stato 83 candidate pipeline |
+| `dataset-incubator` | `registry/clean_catalog.json` | 63 dataset pubblicati (slug, colonne, periodo) |
+| `data-explorer` | `src/data/themes.json.py` | 6 temi editoriali + gap explorer |
 
-Usa `agent-context-mcp` / `dataciviclab-context` per leggere gli artifact remoti.
-Non richiede checkout locale.
+## Tool MCP
 
-```bash
-pip install -e ".[mcp]"
-agent-context-mcp
+Esposti via `agent-context-mcp` (server MCP `dataciviclab-context`).
+
+| Tool | Output | Quando usarlo |
+|---|---|---|
+| `session_bootstrap()` | Markdown | Prima chiamata della sessione — orientamento: segnali, PR, discussion, radar |
+| `workspace_triage()` | JSON | Dati precisi: conteggi, stato git, source health, pipeline state |
+| `topic_index(resolve=)` | JSON | Esplorare dataset/analisi per tema o slug |
+| `search(query, limit=10)` | JSON | Cercare in tutto il Lab: issue, PR, dataset, analisi |
+| `refresh_context()` | OK/error | Forzare rebuild CI (richiede GITHUB_TOKEN con scope workflow) |
+
+### `search()` nel dettaglio
+
+Combina due fonti in una risposta:
+
+```
+search("disuguaglianza")
+  ├── GitHub Issues Search API → issue/PR da tutti i repo dataciviclab
+  └── topic_index.json locale → dataset e analisi per nome/slug/fonte
 ```
 
-Tool MCP:
+Senza `GITHUB_TOKEN` funziona solo su dataset e analisi (topic_index).
 
-| Tool | Uso |
-|---|---|---|
-| `session_bootstrap` | orientamento rapido: repo attivi, PR, issue, discussion |
-| `workspace_triage` | triage machine-readable: PR, issue, warning, git state |
-| `topic_index` | indice v2: repos, datasets per fonte, topic operativi |
-| `search(query, limit=10)` | cerca cross-repo in issue, PR, dataset e analisi (GitHub Search API + topic_index) |
-| `refresh_context` | triggera build CI; richiede `GITHUB_TOKEN` con scope `workflow` |
+Esempio di risposta:
 
-Esempio `settings.json`:
+```json
+{
+  "query": "rifiuti",
+  "total": 9,
+  "results": {
+    "issues": [
+      {"repo": "dataciviclab/data-explorer", "number": 201, "title": "feat: add ISPRA GHG...", "type": "pr"}
+    ],
+    "datasets": [
+      {"slug": "ispra_ru_base", "name": "Rifiuti Urbani", "source": "ISPRA"}
+    ],
+    "analyses": [
+      {"slug": "rifiuti-km2", "name": "Rifiuti per km²..."}
+    ]
+  }
+}
+```
+
+### Configurazione MCP
 
 ```json
 {
@@ -65,66 +85,41 @@ Esempio `settings.json`:
     "dataciviclab-context": {
       "command": "agent-context-mcp",
       "env": {
-        "GITHUB_TOKEN": "<opzionale-per-refresh>"
+        "GITHUB_TOKEN": "<opzionale: serve per refresh_context e search issues>"
       }
     }
   }
 }
 ```
 
-### Local mode
-
-Esegue il builder localmente per includere lo stato git (branch, dirty).
+## Utilizzo locale
 
 ```bash
-pip install -e .
-agent-context build \
-  --config dataciviclab.config.yml \
-  --out generated/ \
+pip install -e ".[mcp]"
+
+# Solo GitHub (stato CI)
+agent-context build --config dataciviclab.config.yml --out generated/
+
+# Con stato git locale
+agent-context build --config dataciviclab.config.yml --out generated/ \
   --workspace-root ~/dev/dataciviclab-workspace
 ```
 
-Windows:
-
-```powershell
-.\codex-context.ps1 -WorkspaceRoot "C:\path\to\dataciviclab-workspace"
-```
-
-Il wrapper imposta UTF-8, neutralizza `CURL_CA_BUNDLE` ereditato e usa `.venv314`
-o `.venv` se presenti.
-
-## Configurazione (`dataciviclab.config.yml`)
-
-Definisce organizzazione, repo e topic da monitorare.
-
-```yaml
-github_org: dataciviclab
-repos:
-  - dataset-incubator
-  - dataciviclab
-topics:
-  datasets:
-    summary: Incubazione dataset
-    repos: [dataset-incubator, dataciviclab]
-    paths: [dataset-incubator/, dataciviclab/analisi/]
-```
-
-`workspace_root` resta fuori dalla config: usare `--workspace-root` o
-`DATACIVICLAB_WORKSPACE`. `GITHUB_TOKEN` serve per GitHub Discussions e refresh CI.
-
-Variabili MCP utili: `ACB_REPO`, `ACB_BRANCH`.
+Variabili ambiente utili:
+- `GITHUB_TOKEN` — per discussion, refresh, search issues
+- `DATACIVICLAB_WORKSPACE` — path workspace locale
+- `ACB_REPO`, `ACB_BRANCH` — override repo/branch MCP (default: `dataciviclab/agent-context-builder`, `context`)
 
 ## Degradazione controllata
 
-Il builder non deve crashare per contesto parziale:
+Nessun crash per contesto parziale:
 
 | Condizione | Comportamento |
 |---|---|
 | rate limit / 403 GitHub | campi `null`, errore in JSON |
-| repo privato senza token | repo saltato, warning registrato |
-| nessun token | discussion saltate; `search()` usa solo topic_index (senza GitHub Search API) |
+| nessun token | discussion e search issues saltate; topic_index search funziona |
+| repo upstream non disponibile | `available: false`, articolazioni interne populate |
 | repo locale assente | `available: false`, `reason: path_not_found` |
-| path non git | `available: false`, `reason: not_git_repo` |
 | local mode non attivo | `available: false`, `reason: local_disabled` |
 
 ## Sviluppo
@@ -132,7 +127,7 @@ Il builder non deve crashare per contesto parziale:
 ```bash
 pip install -e ".[dev]"
 pytest
-ruff check .
+ruff check src/ tests/
 ```
 
 ## Licenza

--- a/src/agent_context_builder/mcp_server.py
+++ b/src/agent_context_builder/mcp_server.py
@@ -360,6 +360,177 @@ def refresh_context() -> dict[str, object]:
     return guard_timed(_exec, "refresh_context")
 
 
+def _search_github_issues(
+    query: str, token: str | None, limit: int = 10
+) -> list[dict[str, object]]:
+    """Search issues and PRs across dataciviclab org via GitHub Search API.
+
+    Args:
+        query: Search query (natural language, full-text on title + body)
+        token: GitHub token (optional; affects rate limit)
+        limit: Max results (default 10, max 50)
+
+    Returns:
+        List of matching issues/PRs with repo, number, title, state, url, type.
+    """
+    url = "https://api.github.com/search/issues"
+    headers = (
+        {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
+        if token
+        else {}
+    )
+    params = {
+        "q": f"{query} org:dataciviclab",
+        "sort": "updated",
+        "order": "desc",
+        "per_page": min(limit, 50),
+    }
+    client = HttpClient(timeout=10)
+    try:
+        result = client.get(url, params=params, headers=headers)
+    except Exception as exc:
+        _log.warning("search_issues", "http_error", error=str(exc))
+        return []
+
+    if not result.is_ok or result.response is None:
+        _log.warning("search_issues", "failed", error=str(result.err))
+        return []
+
+    try:
+        response = result.response
+        data = response.json()
+        items = data.get("items", [])
+    except Exception as exc:
+        _log.warning("search_issues", "parse_error", error=str(exc))
+        return []
+
+    results = []
+    for item in items:
+        repo_full = item.get("repository_url", "").replace("https://api.github.com/repos/", "")
+        results.append(
+            {
+                "repo": repo_full or "",
+                "number": item.get("number"),
+                "title": item.get("title", ""),
+                "state": item.get("state", ""),
+                "url": item.get("html_url", ""),
+                "type": "pr" if "pull_request" in item else "issue",
+                "updated_at": item.get("updated_at", ""),
+            }
+        )
+    return results
+
+
+def _search_topic_index(query: str, topic_data: dict) -> dict[str, list[dict[str, object]]]:
+    """Search datasets and analyses in the topic_index data.
+
+    Args:
+        query: Search query (case-insensitive substring match)
+        topic_data: Parsed topic_index.json content
+
+    Returns:
+        Dict with 'datasets' and 'analyses' lists.
+    """
+    q = query.lower()
+    datasets_found: list[dict[str, object]] = []
+    analyses_found: list[dict[str, object]] = []
+
+    # Search datasets by slug, name, source
+    seen_slugs: set[str] = set()
+    for section in ("datasets_by_source", "candidates_by_source"):
+        entries = topic_data.get(section, {})
+        for source, datasets in entries.items():
+            for ds in datasets:
+                slug = ds.get("slug", "")
+                name = ds.get("name", "")
+                if slug not in seen_slugs and (
+                    q in slug.lower() or q in name.lower() or q in source.lower()
+                ):
+                    seen_slugs.add(slug)
+                    datasets_found.append(
+                        {
+                            "slug": slug,
+                            "name": name,
+                            "source": source,
+                            "period": ds.get("period"),
+                            "stage": "published"
+                            if section == "datasets_by_source"
+                            else "incubating",
+                        }
+                    )
+
+    # Search analyses by slug, name, datasets
+    for analysis in topic_data.get("analyses", []):
+        a_slug = analysis.get("slug", "")
+        a_name = analysis.get("name", "")
+        a_datasets = " ".join(analysis.get("datasets", []))
+        if q in a_slug.lower() or q in a_name.lower() or q in a_datasets.lower():
+            analyses_found.append(
+                {
+                    "slug": a_slug,
+                    "name": a_name,
+                    "datasets": analysis.get("datasets", []),
+                    "status": analysis.get("status", ""),
+                }
+            )
+
+    return {"datasets": datasets_found, "analyses": analyses_found}
+
+
+@mcp.tool(
+    description=(
+        "Cerca in issue, PR, dataset e analisi del DataCivicLab. "
+        "Combina GitHub Search API (issue/PR full-text) con l'indice locale "
+        "(dataset, analisi). I risultati sono raggruppati per tipo."
+    ),
+    structured_output=True,
+)
+def search(query: str, limit: int = 10) -> dict[str, object]:
+    """Search across the DataCivicLab ecosystem.
+
+    Args:
+        query: Testo da cercare (es. \"disuguaglianza\", \"sanità\", \"appalti\")
+        limit: Massimo risultati per sezione (default 10, max 50)
+
+    Returns:
+        Risultati raggruppati per tipo (issues, datasets, analyses).
+    """
+
+    def _exec() -> dict[str, object]:
+        token = _get_env("GITHUB_TOKEN")
+
+        # 1. Search GitHub Issues + PRs
+        issues = _search_github_issues(query, token, limit)
+
+        # 2. Fetch topic_index and search datasets + analyses
+        try:
+            topic_raw = _fetch("topic_index.json", retries=0)
+            topic_data = json.loads(topic_raw)
+        except Exception as exc:
+            _log.warning("search", "topic_index_fetch_failed", error=str(exc))
+            topic_data = {}
+
+        local = (
+            _search_topic_index(query, topic_data)
+            if topic_data
+            else {"datasets": [], "analyses": []}
+        )
+
+        total = len(issues) + len(local["datasets"]) + len(local["analyses"])
+        return {
+            "query": query,
+            "total": total,
+            "results": {
+                "issues": issues,
+                "datasets": local["datasets"],
+                "analyses": local["analyses"],
+            },
+            "ok": True,
+        }
+
+    return guard_timed(_exec, "search")
+
+
 def main() -> None:
     """Entry point per l'MCP server."""
     _log.info("main", "starting", repo=_REPO, branch=_BRANCH)

--- a/src/agent_context_builder/mcp_server.py
+++ b/src/agent_context_builder/mcp_server.py
@@ -17,6 +17,7 @@ Configuration via environment variables:
 
 import json
 import os
+import re
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -421,17 +422,40 @@ def _search_github_issues(
     return results
 
 
+def _word_match(query: str, text: str) -> bool:
+    """Check if each word of query appears as a whole word in text.
+
+    Uses ``\\b`` word boundary — ``\"pubblica\"`` matches ``\"finanza pubblica\"``
+    but NOT ``\"pubblicati\"``. Case-insensitive.
+
+    Args:
+        query: Search query (one or more words)
+        text: Text to search in
+
+    Returns:
+        True if ALL words in query appear as whole words in text.
+    """
+    words = query.lower().split()
+    text_lower = text.lower()
+    for word in words:
+        if not re.search(r"\b" + re.escape(word) + r"\b", text_lower):
+            return False
+    return True
+
+
 def _search_topic_index(query: str, topic_data: dict) -> dict[str, list[dict[str, object]]]:
     """Search datasets and analyses in the topic_index data.
 
+    Uses word-boundary matching (``_word_match``) on slug, name, and source
+    to avoid false positives from substring matches.
+
     Args:
-        query: Search query (case-insensitive substring match)
+        query: Search query
         topic_data: Parsed topic_index.json content
 
     Returns:
         Dict with 'datasets' and 'analyses' lists.
     """
-    q = query.lower()
     datasets_found: list[dict[str, object]] = []
     analyses_found: list[dict[str, object]] = []
 
@@ -444,7 +468,10 @@ def _search_topic_index(query: str, topic_data: dict) -> dict[str, list[dict[str
                 slug = ds.get("slug", "")
                 name = ds.get("name", "")
                 if slug not in seen_slugs and (
-                    q in slug.lower() or q in name.lower() or q in source.lower()
+                    query.lower()
+                    in slug.lower()  # substring su slug (identificatori con underscore)
+                    or _word_match(query, name)  # word boundary su name (testo umano)
+                    or _word_match(query, source)  # word boundary su source (testo umano)
                 ):
                     seen_slugs.add(slug)
                     datasets_found.append(
@@ -464,7 +491,11 @@ def _search_topic_index(query: str, topic_data: dict) -> dict[str, list[dict[str
         a_slug = analysis.get("slug", "")
         a_name = analysis.get("name", "")
         a_datasets = " ".join(analysis.get("datasets", []))
-        if q in a_slug.lower() or q in a_name.lower() or q in a_datasets.lower():
+        if (
+            query.lower() in a_slug.lower()  # substring su slug analisi
+            or _word_match(query, a_name)  # word boundary su nome analisi
+            or query.lower() in a_datasets.lower()  # substring su dataset collegati
+        ):
             analyses_found.append(
                 {
                     "slug": a_slug,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -403,6 +403,47 @@ def test_search_topic_index_no_match():
 
 
 @pytest.mark.contract
+def test_search_topic_index_word_boundary():
+    """_search_topic_index uses word boundary on name: 'pubblica' ∌ 'pubblicati'."""
+    topic = {
+        "datasets_by_source": {
+            "Terna": [
+                {
+                    "slug": "terna_capacita_rinnovabile",
+                    "name": "Terna Capacità Rinnovabile",
+                    "period": {"start": 2015},
+                },
+            ],
+            "MEF": [
+                {
+                    "slug": "dipendenti_pubblici",
+                    "name": "Dipendenti Pubblici",
+                    "period": {"start": 2010},
+                },
+            ],
+        },
+        "analyses": [],
+    }
+    # 'pubblica' in source "dati pubblicati su terna.com" era un falso positivo
+    # Con word boundary: NON deve matchare
+    source_terna = "Terna S.p.A. — dati pubblicati su terna.com"
+    topic["datasets_by_source"]["Terna"][0]["source"] = source_terna
+    topic["datasets_by_source"]["MEF"][0]["source"] = "MEF"
+
+    result = mcp_server._search_topic_index("pubblica", topic)
+    slugs = [d["slug"] for d in result["datasets"]]
+    assert "terna_capacita_rinnovabile" not in slugs, (
+        "word boundary: 'pubblica' non deve matchare 'pubblicati'"
+    )
+    # 'pubblici' DEVE matchare (parola intera in nome/slug)
+    result2 = mcp_server._search_topic_index("pubblici", topic)
+    slugs2 = [d["slug"] for d in result2["datasets"]]
+    assert "dipendenti_pubblici" in slugs2, (
+        "'pubblici' deve matchare 'dipendenti_pubblici' via slug (substring)"
+    )
+
+
+@pytest.mark.contract
 def test_search_topic_index_empty_topic():
     """_search_topic_index handles empty topic data gracefully."""
     assert mcp_server._search_topic_index("test", {}) == {"datasets": [], "analyses": []}

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -354,3 +354,176 @@ def test_refresh_context_api_error(monkeypatch):
 
     assert result["ok"] is False
     assert result["status_code"] == 403
+
+
+# ── search ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.contract
+def test_search_topic_index_matches_name():
+    """_search_topic_index matches dataset slug, name and source case-insensitive."""
+    topic = {
+        "datasets_by_source": {
+            "ISPRA": [
+                {"slug": "ispra_ru_base", "name": "Rifiuti Urbani", "period": {"start": 2020}},
+            ],
+            "MEF": [
+                {"slug": "irpef_comunale", "name": "IRPEF Comunale", "period": {"start": 2019}},
+            ],
+        },
+        "analyses": [
+            {
+                "slug": "irpef-comunale",
+                "name": "IRPEF Comunale 2019-2023",
+                "datasets": ["irpef_comunale"],
+                "status": "active",
+            },
+        ],
+    }
+    result = mcp_server._search_topic_index("rifiuti", topic)
+    assert len(result["datasets"]) == 1
+    assert result["datasets"][0]["slug"] == "ispra_ru_base"
+
+    result2 = mcp_server._search_topic_index("irpef", topic)
+    assert len(result2["datasets"]) == 1
+    assert len(result2["analyses"]) == 1
+    assert result2["analyses"][0]["slug"] == "irpef-comunale"
+
+
+@pytest.mark.contract
+def test_search_topic_index_no_match():
+    """_search_topic_index returns empty lists when nothing matches."""
+    topic = {
+        "datasets_by_source": {"ISTAT": [{"slug": "popolazione", "name": "Popolazione"}]},
+        "analyses": [],
+    }
+    result = mcp_server._search_topic_index("clima", topic)
+    assert result["datasets"] == []
+    assert result["analyses"] == []
+
+
+@pytest.mark.contract
+def test_search_topic_index_empty_topic():
+    """_search_topic_index handles empty topic data gracefully."""
+    assert mcp_server._search_topic_index("test", {}) == {"datasets": [], "analyses": []}
+
+
+@pytest.mark.adapter
+def test_search_github_issues_api_error():
+    """_search_github_issues returns empty list on API error instead of raising."""
+    fake = FakeHttpClient()
+    search_url = "https://api.github.com/search/issues"
+    fake.responses[search_url] = HttpResult(
+        response=None,
+        err=RuntimeError("403 rate limit exceeded"),
+    )
+    with patch("agent_context_builder.mcp_server.HttpClient") as mock_cls:
+        mock_cls.return_value = fake
+        result = mcp_server._search_github_issues("test", "fake-token", limit=5)
+
+    assert result == []
+
+
+@pytest.mark.adapter
+def test_search_github_issues_malformed_json():
+    """_search_github_issues handles malformed JSON response."""
+    fake = FakeHttpClient()
+    url = "https://api.github.com/search/issues"
+    fake.responses[url] = HttpResult(
+        response=fake_response(200, text="not json"),
+        err=None,
+    )
+    with patch("agent_context_builder.mcp_server.HttpClient") as mock_cls:
+        mock_cls.return_value = fake
+        result = mcp_server._search_github_issues("test", "fake-token", limit=5)
+
+    assert result == []
+
+
+@pytest.mark.adapter
+def test_search_github_issues_success():
+    """_search_github_issues parses valid search results correctly."""
+    fake = FakeHttpClient()
+    url = "https://api.github.com/search/issues"
+    fake.responses[url] = HttpResult(
+        response=fake_response(
+            200,
+            json_data={
+                "total_count": 1,
+                "items": [
+                    {
+                        "number": 42,
+                        "title": "Test issue about rifiuti",
+                        "state": "open",
+                        "html_url": "https://github.com/dataciviclab/test-repo/issues/42",
+                        "repository_url": "https://api.github.com/repos/dataciviclab/test-repo",
+                        "updated_at": "2026-07-14T10:00:00Z",
+                    },
+                ],
+            },
+        ),
+        err=None,
+    )
+    with patch("agent_context_builder.mcp_server.HttpClient") as mock_cls:
+        mock_cls.return_value = fake
+        result = mcp_server._search_github_issues("rifiuti", "fake-token", limit=5)
+
+    assert len(result) == 1
+    assert result[0]["number"] == 42
+    assert result[0]["repo"] == "dataciviclab/test-repo"
+    assert result[0]["type"] == "issue"
+    assert result[0]["state"] == "open"
+
+
+@pytest.mark.adapter
+def test_search_github_issues_detects_pr():
+    """_search_github_issues marks items with pull_request field as type 'pr'."""
+    fake = FakeHttpClient()
+    url = "https://api.github.com/search/issues"
+    fake.responses[url] = HttpResult(
+        response=fake_response(
+            200,
+            json_data={
+                "total_count": 1,
+                "items": [
+                    {
+                        "number": 99,
+                        "title": "feat: add new dataset",
+                        "state": "open",
+                        "html_url": "https://github.com/dataciviclab/repo/pull/99",
+                        "repository_url": "https://api.github.com/repos/dataciviclab/repo",
+                        "pull_request": {"url": "..."},
+                        "updated_at": "2026-07-14T10:00:00Z",
+                    },
+                ],
+            },
+        ),
+        err=None,
+    )
+    with patch("agent_context_builder.mcp_server.HttpClient") as mock_cls:
+        mock_cls.return_value = fake
+        result = mcp_server._search_github_issues("dataset", "fake-token", limit=5)
+
+    assert len(result) == 1
+    assert result[0]["type"] == "pr"
+
+
+@pytest.mark.contract
+def test_search_tool_no_token(monkeypatch):
+    """search() works without token (just topic_index search)."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("ACB_ENV_FILE", "")
+    monkeypatch.setattr(mcp_server, "_ENV_LOADED", True)
+
+    fake = FakeHttpClient()
+    _patch_fetch(fake, "topic_index.json", text='{"datasets_by_source": {}, "analyses": []}')
+
+    with patch("agent_context_builder.mcp_server.HttpClient") as mock_cls:
+        mock_cls.return_value = fake
+        result = mcp_server.search(query="test", limit=5)
+
+    assert result["ok"] is True
+    assert result["query"] == "test"
+    assert "issues" in result["results"]
+    assert "datasets" in result["results"]
+    assert "analyses" in result["results"]


### PR DESCRIPTION
## Cosa fa

Aggiunge il tool MCP `search(query, limit=10)` all'MCP server `dataciviclab-context`.

Combina due fonti in una risposta unificata:

### 1. GitHub Issues Search API (real-time)

Cerca in **tutti i repo dell'org** dataciviclab — issue e PR, full-text su titolo e body.

```
GET /search/issues?q={query}+org:dataciviclab
```

Distingue automaticamente issue da PR (`type: issue | pr`).

### 2. topic_index.json locale

Cerca nei dataset (slug, name, source) e nelle analisi (slug, name, datasets) dell'indice ACB — nessuna API necessaria.

## Degradazione

| Condizione | Comportamento |
|---|---|
| Rate limit GitHub | Issues vuoti, topic_index funziona |
| Token non presente | Issues vuoti, topic_index funziona |
| topic_index non fetchabile | Dataset/analisi vuoti, issues funzionano |

## Test

8 nuovi test — 133 totali, tutti verdi, coverage 81%.

## Closes

Parte del percorso cross-repo search.